### PR TITLE
Adding project governance documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# **Contributing to Tangle**
+
+First off, thank you for considering contributing to Tangle\! We're excited to have you here. This project is open-source, and we value every contribution, from bug reports to new features.
+
+This document guides you through the process.
+
+**Quick Links:**
+
+* `GOVERNANCE.md` Project Governance (How we make decisions)
+* `SECURITY.md` How to report vulnerabilities
+* [Issue Tracker](https://github.com/TangleML/tangle/issues)
+
+## **📜 How to Contribute**
+
+We welcome contributions of all kinds\! Here are a few ways you can help:
+
+* **🐛 Report Bugs:** If you find a bug, please [open an issue](https://github.com/TangleML/tangle/issues/new?template=bug_report.md). Include as much detail as possible, like your environment, steps to reproduce, and the expected outcome.
+* **✨ Request Features:** Have an idea? [Open a feature request](https://github.com/TangleML/tangle/issues/new?template=feature_request.md). We'd love to hear it.
+* **📝 Improve Documentation:** If you see typos or areas where docs could be clearer, please submit a Pull Request\!
+* **🧑‍💻 Write Code:** Help us fix bugs or build new features.
+
+## **🧑‍💻 Your First Code Contribution**
+
+Ready to submit your code? Here's the workflow we follow for external contributors.
+
+### **1\. Set Up Your Environment**
+
+1. **Fork** the repository to your own GitHub account.
+2. **Clone** your fork to your local machine:
+3. Create a **new branch** for your changes:
+
+### **2\. Make Your Changes**
+
+Write your code, write your tests, and make sure all existing tests pass.
+
+### **3\. Contributor License Agreement**
+
+We require that all contributions adhere to the **Developer Certificate of Origin (DCO)** https://developercertificate.org and **the Apache 2.0 License** https://opensource.org/license/apache-2-0. By submitting a Pull Request, you are certifying that you agree to these terms.
+
+This ensures that:
+
+1. You have the right to submit this code.
+2. Your contribution will be licensed under the project's **Apache License 2.0**.
+
+This is the full text of the DCO:
+
+**Developer's Certificate of Origin 1.1**
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+
+### **4\. Submit a Pull Request**
+
+1. Push your branch to GitHub.
+2. Go to the Tangle repository on GitHub and open a **Pull Request (PR)**.
+3. In your PR description, explain *what* you changed and *why*. If your PR fixes an open issue, link to it using `Closes #123`.
+4. A Maintainer will be assigned to review your PR. They may ask for changes.
+5. Once your PR is approved and all CI checks pass, a Maintainer will merge it into the main branch.
+
+That's it\! We're incredibly grateful for your contribution.
+

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,168 @@
+# **Project Tangle Governance**
+
+## **Tangle Software Vision**
+
+The Tangle system helps users create and run ML experiments and production pipelines. Any batch workflow that has beginning and end can be orchestrated via a pipeline.
+
+## **Tangle Project Governance Vision**
+
+Grow the project in a manner that welcomes a wide community of stakeholders and enables the future handoff to a vendor-neutral non-profit foundation.
+
+## **Purpose and scope**
+
+* This document outlines the governance model for the Tangle project, including how decisions are made and how various community members can get involved.
+* Applies to all repositories under https://github.com/TangleML and affiliated tooling, documentation, and community channels.
+
+## **Values**
+
+* Transparency: Decisions and rationales are public and recorded.
+* Inclusivity and neutrality: Multiple organizations and independent contributors can participate meaningfully.
+* Security and quality: Changes meet defined standards and guardrails.
+* Sustainability: Reduce single-maintainer/vendor risk and build a healthy maintainer pipeline.
+
+## **A three-pillar governance model**
+
+1. Alexey Volkov @Ark-kun \- founder and Project Lead.
+2. Open Source Community \- can contribute code, become maintainers and join Technical Steering Committee (TSC) once it is formed.
+3. Shopify \- initial sponsor, administrator of GitHub & security response, owner of domains and trademarks.
+
+## **Project structure**
+
+* License: Project consists of Open Source Software licensed under the Apache License, version 2.0 in `LICENSE`.
+* Components:
+  * [tangle](https://github.com/TangleML/tangle) \- Tangle is a web app that allows the users to build and run Machine Learning pipelines without having to set up a development environment.
+  * [tangle-ui](https://github.com/TangleML/tangle-ui) \- Tangle frontend code \- based on Cloud Pipelines Studio
+  * [website](https://github.com/TangleML/website) \- The source code for [TangleML.com](https://TangleML.com)
+* Releases:
+  * [https://github.com/TangleML/tangle/releases](https://github.com/TangleML/tangle/releases)
+  * [https://github.com/TangleML/tangle-ui/releases](https://github.com/TangleML/tangle-ui/releases)
+  * [https://huggingface.co/TangleML](https://huggingface.co/TangleML)
+  * PyPI (details TBD)
+* Documents: `LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `RELEASING.md`, `TRADEMARK.pdf`
+
+## **1\. Roles**
+
+This project formally recognizes the following roles.
+
+### **👤 Everyone (Users)**
+
+Anyone who uses the project is a community member. We value your contributions, and you are encouraged to:
+
+* Use the software.
+* Provide feedback and report bugs by opening Issues.
+* Join community discussions (e.g., on GitHub, Slack, or mailing lists).
+* Advocate for the project.
+
+### **🧑‍💻 Contributors**
+
+A **Contributor** is anyone who makes a contribution to the project. Contributions can include:
+
+* Submitting code via a Pull Request (PR).
+* Improving documentation.
+* Reviewing PRs from other contributors.
+* Triaging issues and helping other users.
+
+Contributors are expected to follow the project's [Contributing Guidelines](https://github.com/TangleML/tangle/blob/master/CONTRIBUTING.md).
+
+### **🧑‍🔧 Maintainers**
+
+**Maintainers** are active and trusted contributors who have demonstrated a long-term commitment to the project. They have **write access** to the repository and are responsible for its day-to-day health. More details on how to become a project maintainer are listed below.
+
+**Responsibilities:**
+
+* Reviewing and merging Pull Requests.
+* Guiding the project's technical direction.
+* Triaging and managing issues.
+* Helping new contributors.
+
+The current list of Maintainers is:
+
+* *tangle*
+  * @Ark-kun
+* *tangle-ui*
+  * @Ark-kun
+  * @camielvs
+  * @maxy-shpfy
+  * @Mbeaulne
+* *website*
+  * @Ark-kun
+  * @maxy-shpfy
+
+### **🚀 Release Managers**
+
+* Coordinate releases, tags, changelogs, artifact signing, and backports.
+* Operate per `RELEASING.md`.
+* The Release Managers is a subset of the maintainers that are assigned additional system permissions to perform the release process. (for example to publish to PyPi)
+
+### **🛡️ Security Team**
+
+* Receives and triages private vulnerability reports; coordinates fixes and advisories.
+* Operates per `SECURITY.md`; may include external members approved by the Project Lead or TSC.
+
+### **👑 Project Lead**
+
+For a new project, transparency is key. Tangle has been started with a Project Lead to drive the project. The project and Project Lead are supported by Shopify.
+
+The **Project Lead** is responsible for the overall strategic vision of the project and for making final decisions when community consensus cannot be reached.
+
+* **Project Lead:** Alexey Volkov @Ark-kun
+
+As the project grows, this role will be retired and transferred to a Technical Steering Committee.
+
+### **🏛️ Technical Steering Committee (TSC)**
+
+The Technical Steering Committee will grow as an organizationally diverse set of maintainers is achieved. Once the size of the TSC reaches 10, the Project Lead role will become an elected role with a 1 year term. The Project Lead chairs the TSC and can appoint new members from the current Maintainers. Once the TSC has 5 members, voting will be introduced to elect new members for 1 year terms.
+
+* Size: 3-10 members, growing with the size of the project. Composition aims for diversity across organizations and expertise.
+* Responsibilities: Strategy, roadmap approval, governance changes, tie-break decisions, high-impact/controversial changes.
+* Publishes meeting notes and decisions.
+* Members of the TSC are a subset of the project Maintainers chosen to represent different community stakeholders. (To retain their TSC seat, TSC members must maintain active maintainer status)
+
+As a reflection of the three pillars vision, 3 seats on the TSC will represent the 3 pillars of Community, Shopify and the Project Leader.
+
+## **2\. Decision Making**
+
+This project operates on a **consensus-seeking** model. We try to find solutions that most members can agree with.
+
+### **Day-to-Day Decisions (Pull Requests)**
+
+1. **Pull Requests** are the primary method for making changes.
+2. PRs should be reviewed by at least one Maintainer who is not the author.
+3. If a PR is straightforward (like a bug fix or documentation) and receives an approval, it can be merged by a Maintainer.
+4. The author of a PR should generally not merge their own PR unless it's a critical fix or they have received explicit approval from another Maintainer.
+
+### **Major Changes & Disagreements**
+
+For substantial changes (e.g., new features, API changes, or changes to the project's direction), a more formal process is used:
+
+1. **Proposal:** The change is proposed by opening a **GitHub Issue** with a clear description.
+2. **Discussion:** The community discusses the proposal. This is the time to raise concerns, suggest alternatives, and build consensus.
+3. **Resolution:**
+   * **Consensus:** If the repository’s Maintainers agree, a Maintainer can mark the proposal as "accepted," and work can begin.
+   * **No Consensus:** If a clear consensus cannot be reached the matter will be escalated to the TSC.
+
+It is expected that a more formal RFC process is instituted for major changes as the project grows. This will be instituted by the Project Lead or Technical Steering Committee and this document updated via the processes in the current version.
+
+## **3\. How to Become a Maintainer**
+
+We actively want our best contributors to become Maintainers. The path is simple: **contribute consistently and help others.**
+
+A new maintainer can be nominated by a current maintainer. Maintainers are voted in by a simple majority among current maintainers. Eligibility to become a maintainer is based on active contribution and volume of at least 30 merged pull requests in the last year. A different set of maintainers may be maintained for each repository (e.g website, tangle, tangleUI). A subset of maintainers will have organization wide permissions and responsibility.  Maintainers can lose their status if they haven’t contributed (code, discussion participation, other duties) in more than one year.
+
+## **4\. Amending This Document**
+
+This governance document is not set in stone. Proposed changes shall be made public for 30 days and decisions will be made by the TSC.
+
+## **5\. Project Infrastructure**
+
+Project infrastructure such as GitHub, CI, Hugging Face, PyPi, etc. are administered by the TSC with access permissions assigned to Maintainers, Release Managers, and Security Team members in accordance with this document.
+
+## **6\. Ownership**
+
+Shopify is the owner of the Tangle name, Trademark, Logo and Domain. In the event of Shopify losing interest in developing and maintaining the project, Shopify plans to donate these assets to a suitable steward. It is intended that that suitable steward might be an appropriate vendor-neutral non-profit open source foundation (for example, CNCF).
+
+## **Contact**
+
+* General questions: (TBD: Google Groups? Slack?)
+* Security reports: [https://github.com/TangleML/tangle/security](https://github.com/TangleML/tangle/security)
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# **Release Process**
+
+This document outlines the process and policies for creating a new release of the Tangle project.
+
+This guide is primarily intended for project Maintainers and designated **Release Managers** (as defined in `GOVERNANCE.md`).
+
+## **1\. Versioning**
+
+Tangle follows **Semantic Versioning 2.0.0** (https://semver.org/\#semantic-versioning-200). All release tags must adhere to this specification.
+
+Given a version number `MAJOR.MINOR.PATCH`, we increment:
+
+* `MAJOR` version for incompatible, breaking API changes.
+* `MINOR` version for new, backwards-compatible functionality.
+* `PATCH` version for backwards-compatible bug fixes.
+
+**Pre-1.0.0:** While the project is in its early stages (version `0.x.y`), breaking changes may be introduced in `MINOR` releases.
+
+## **2\. Release Cadence**
+
+Tangle does not have a fixed release schedule (e.g., "every 6 weeks").
+
+* **Minor/Major** releases are cut when a sufficient number of features or changes have accumulated on the `main` branch.
+* **Patch** releases are made on-demand to address critical bugs or security vulnerabilities.
+
+## **3\. Release Process**
+
+Releases will be available at https://github.com/TangleML/tangle/releases
+
+Releases will be published to PyPI and/or Hugging Face (details TBD)
+
+Update the website and documentation https://tangleml.com/
+
+Any disputes or disagreements related to the release process will be handled in accordance with the decision making section of GOVERNANCE.md.
+
+## **4\. Support & Backport Policy**
+
+* **Supported Versions:** We provide active support for the **latest `MINOR` release** (e.g., `v0.2.x`).
+* **Security Fixes:** Critical security vulnerabilities will be backported to the previous `MINOR` release, at the discretion of the Security Team.
+* **Bug Fixes:** We do not generally backport non-critical bug fixes. We encourage all users to upgrade to the latest version.
+
+## Appendix
+
+Current list of Release Managers:
+
+* @Ark-kun
+* @camielvs
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# **Security Policy**
+
+The Tangle team takes the security of our project seriously. We appreciate the efforts of security researchers and our community to help us ensure our software is secure.
+
+## **Reporting a Vulnerability**
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+We use GitHub's Private Vulnerability Reporting feature, which allows you to privately disclose a security vulnerability to the project maintainers.
+
+1. **Go to the "Security" tab** of the Tangle repository.
+2. Click on **"Report a vulnerability"** or go directly to `https://github.com/TangleML/tangle/security/advisories/new`
+3. Fill out the form with as much detail as possible, including:
+   * A description of the vulnerability.
+   * The component or code path affected.
+   * The version(s) affected.
+   * Steps to reproduce the issue or a proof-of-concept (PoC).
+   * Any potential impact (e.g., data exfiltration, denial of service).
+
+### **Alternative Contact**
+
+If for any reason you cannot use GitHub's private reporting, you can send an email to our private security-list: **`security@tangleml.com`**. Please use "Tangle Security Vulnerability" as the subject line.
+
+## **Our Commitment**
+
+When you report a vulnerability to us, we commit to the following:
+
+* We will acknowledge your report within **5 business days**.
+* We will work with you to understand the issue and confirm its validity.
+* We will provide a timeline for a fix and keep you updated on our progress.
+* We will coordinate with you on a public disclosure and advisory. We will credit you for your discovery unless you prefer to remain anonymous.
+


### PR DESCRIPTION
Added the following documents to help the project grow and welcome a community of users, contributors and stakeholders:
GOVERNANCE.md
-project governance
CONTRIBUTING.md
-contributor guidelines
RELEASING.md
-release process and policies
SECURITY.md
-security policy and vulnerability reporting and handling