### PR TITLE
feat: Add pipeline run outcome metrics

### DIFF
--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -30,6 +30,7 @@ from . import component_structures as structures
 from . import backend_types_sql as bts
 from . import errors
 from .errors import ItemNotFoundError
+from .instrumentation import metrics
 
 
 # ==== PipelineJobService
@@ -111,6 +112,10 @@ class PipelineRunsApiService_Sql:
             session.commit()
 
         session.refresh(pipeline_run)
+
+        # Track pipeline creation metric
+        metrics.track_pipeline_created(created_by=created_by)
+
         return PipelineRunResponse.from_db(pipeline_run)
 
     def get(self, session: orm.Session, id: bts.IdType) -> PipelineRunResponse:


### PR DESCRIPTION
# Pipeline Metrics Instrumentation

Tracks pipeline lifecycle from creation to completion with labels for status and user.

Metrics added:
- pipeline_runs_total: Counter tracking pipeline runs by status (running/succeeded/failed/cancelled) and created_by
- pipeline_run_duration_seconds: Histogram tracking total pipeline duration by final status

These metrics provide visibility into pipeline success rates, completion times, and usage patterns per user.
Durations measure total lifecycle time from creation to terminal state (including queue and execution time).