### PR TITLE
fix: Contextual logging import to use absolute path

### DIFF
--- a/cloud_pipelines_backend/instrumentation/structured_logging.py
+++ b/cloud_pipelines_backend/instrumentation/structured_logging.py
@@ -6,7 +6,7 @@ contextual_logging module to automatically include context metadata in log recor
 
 import logging
 
-from . import contextual_logging
+from cloud_pipelines_backend.instrumentation import contextual_logging
 
 
 class LoggingContextFilter(logging.Filter):


### PR DESCRIPTION
Changed the import in structured_logging.py from relative to absolute to ensure that the same contextual_logging module instance is used across all imports. This fixes an issue where context metadata set in one module was not visible in another due to separate module instances having separate ContextVar objects.

This ensures LoggingContextFilter and contextual_logging.logging_context share the same _context_metadata ContextVar, allowing contextual data like container_execution_id and execution_node_ids to appear in logs.