### PR TITLE
feat: API Server - Pipeline runs - Made it possible to get pipeline run execution summary when using the get method

### DIFF
--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -157,11 +157,21 @@ class PipelineRunsApiService_Sql:
         session.refresh(pipeline_run)
         return PipelineRunResponse.from_db(pipeline_run)
 
-    def get(self, session: orm.Session, id: bts.IdType) -> PipelineRunResponse:
+    def get(
+        self,
+        session: orm.Session,
+        id: bts.IdType,
+        include_execution_stats: bool = False,
+    ) -> PipelineRunResponse:
         pipeline_run = session.get(bts.PipelineRun, id)
         if not pipeline_run:
             raise errors.ItemNotFoundError(f"Pipeline run {id} not found.")
-        return PipelineRunResponse.from_db(pipeline_run)
+        response = PipelineRunResponse.from_db(pipeline_run)
+        if include_execution_stats:
+            response = self._populate_execution_stats(
+                session=session, response=response
+            )
+        return response
 
     def terminate(
         self,
@@ -275,12 +285,22 @@ class PipelineRunsApiService_Sql:
                     )
             response.pipeline_name = pipeline_name
         if include_execution_stats:
-            stats, summary = self._get_execution_stats_and_summary(
-                session=session,
-                root_execution_id=pipeline_run.root_execution_id,
+            response = self._populate_execution_stats(
+                session=session, response=response
             )
-            response.execution_status_stats = stats
-            response.execution_summary = summary
+        return response
+
+    def _populate_execution_stats(
+        self,
+        session: orm.Session,
+        response: PipelineRunResponse,
+    ) -> PipelineRunResponse:
+        stats, summary = self._get_execution_stats_and_summary(
+            session=session,
+            root_execution_id=response.root_execution_id,
+        )
+        response.execution_status_stats = stats
+        response.execution_summary = summary
         return response
 
     def _get_execution_stats_and_summary(

--- a/tests/test_api_server_sql.py
+++ b/tests/test_api_server_sql.py
@@ -1893,3 +1893,67 @@ class TestPipelineRunServiceList:
             assert summary.total_executions == 2
             assert summary.ended_executions == 1
             assert summary.has_ended is False
+
+
+class TestPipelineRunServiceGet:
+    def test_get_not_found(self):
+        session_factory = _initialize_db_and_get_session_factory()
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        with session_factory() as session:
+            with pytest.raises(errors.ItemNotFoundError):
+                service.get(session=session, id="nonexistent-id")
+
+    def test_get_returns_pipeline_run(self):
+        session_factory = _initialize_db_and_get_session_factory()
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        with session_factory() as session:
+            root = _create_execution_node(session=session)
+            root_id = root.id
+            run = _create_pipeline_run(session=session, root_execution=root)
+            run_id = run.id
+            session.commit()
+
+        with session_factory() as session:
+            result = service.get(session=session, id=run_id)
+            assert result.id == run_id
+            assert result.root_execution_id == root_id
+            assert result.execution_status_stats is None
+            assert result.execution_summary is None
+
+    def test_get_with_execution_stats(self):
+        session_factory = _initialize_db_and_get_session_factory()
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        with session_factory() as session:
+            root = _create_execution_node(session=session)
+            root_id = root.id
+            child1 = _create_execution_node(
+                session=session,
+                parent=root,
+                status=bts.ContainerExecutionStatus.SUCCEEDED,
+            )
+            child2 = _create_execution_node(
+                session=session,
+                parent=root,
+                status=bts.ContainerExecutionStatus.RUNNING,
+            )
+            _link_ancestor(session=session, execution_node=child1, ancestor_node=root)
+            _link_ancestor(session=session, execution_node=child2, ancestor_node=root)
+            run = _create_pipeline_run(session=session, root_execution=root)
+            run_id = run.id
+            session.commit()
+
+        with session_factory() as session:
+            result = service.get(
+                session=session, id=run_id, include_execution_stats=True
+            )
+            assert result.id == run_id
+            assert result.root_execution_id == root_id
+            stats = result.execution_status_stats
+            assert stats is not None
+            assert stats["SUCCEEDED"] == 1
+            assert stats["RUNNING"] == 1
+            summary = result.execution_summary
+            assert summary is not None
+            assert summary.total_executions == 2
+            assert summary.ended_executions == 1
+            assert summary.has_ended is False


### PR DESCRIPTION
### TL;DR

Added execution statistics to the pipeline run get endpoint (`GET /api/pipeline_runs/{id}`).

### What changed?

- Enhanced the `get` method to optionally include execution statistics
- Added a new parameter `include_execution_stats` (default: False) to the `get` method
- Extracted the execution stats population logic into a new helper method `_populate_execution_stats`

### How to test?

1. Call the pipeline run get endpoint with `include_execution_stats=True`
2. Verify that the response includes execution status statistics and summary
3. Run the new tests in `TestPipelineRunServiceGet` class to ensure the functionality works as expected

Run the new test cases in `tests/test_api_server_sql.py`:

```bash
pytest tests/test_api_server_sql.py
```

### Why make this change?

- Related to https://github.com/TangleML/tangle/issues/87
- `tangle-deploy` needs to know if a specific pipeline run is completed

![image.png](https://app.graphite.com/user-attachments/assets/7f91b857-6f72-495c-8a40-b27141437fb1.png)