### PR TITLE
Adds migrations - status

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,6 +1,7 @@
 import os
 from logging.config import fileConfig
 
+import sqlalchemy as sa
 from sqlalchemy import engine_from_config, pool
 
 from alembic import context
@@ -79,7 +80,13 @@ def run_migrations_online() -> None:
         with context.begin_transaction():
             context.run_migrations()
 
-    if hasattr(connectable, "connect"):
+    try:
+        connectable.connect
+        is_engine = hasattr(connectable, "pool")
+    except AttributeError:
+        is_engine = False
+
+    if is_engine:
         with connectable.connect() as connection:
             _run_with_connection(connection)
     else:

--- a/alembic/versions/457e50b9271c_add_status_and_has_ended_to_pipeline_run.py
+++ b/alembic/versions/457e50b9271c_add_status_and_has_ended_to_pipeline_run.py
@@ -1,0 +1,140 @@
+"""add status and has_ended to pipeline_run
+
+Revision ID: 457e50b9271c
+Revises: b86b67add848
+Create Date: 2026-02-21 11:22:56.149127
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '457e50b9271c'
+down_revision: Union[str, Sequence[str], None] = 'b86b67add848'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_STATUS_PRIORITY = {
+    "SYSTEM_ERROR": 1,
+    "FAILED": 2,
+    "INVALID": 3,
+    "CANCELLING": 4,
+    "CANCELLED": 5,
+    "RUNNING": 6,
+    "PENDING": 7,
+    "WAITING_FOR_UPSTREAM": 8,
+    "QUEUED": 9,
+    "UNINITIALIZED": 10,
+    "SKIPPED": 11,
+    "SUCCEEDED": 12,
+}
+
+_PRIORITY_TO_STATUS = {v: k for k, v in _STATUS_PRIORITY.items()}
+
+_ENDED_STATUSES = {"INVALID", "SUCCEEDED", "FAILED", "SYSTEM_ERROR", "CANCELLED", "SKIPPED"}
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('pipeline_run', schema=None) as batch_op:
+        batch_op.add_column(sa.Column(
+            'status',
+            sa.Enum(
+                'INVALID', 'UNINITIALIZED', 'QUEUED', 'WAITING_FOR_UPSTREAM',
+                'PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'SYSTEM_ERROR',
+                'CANCELLING', 'CANCELLED', 'SKIPPED',
+                name='containerexecutionstatus',
+            ),
+            nullable=True,
+        ))
+        batch_op.add_column(sa.Column(
+            'has_ended', sa.Boolean(), nullable=False, server_default=sa.text('0'),
+        ))
+        batch_op.create_index(
+            batch_op.f('ix_pipeline_run_status'), ['status'], unique=False,
+        )
+
+    op.create_index(
+        'ix_pipeline_run_status_created_at_desc',
+        'pipeline_run',
+        [sa.text('status'), sa.text('created_at DESC')],
+        unique=False,
+    )
+
+    _backfill_status()
+
+
+def _backfill_status() -> None:
+    """Compute status and has_ended for all existing pipeline runs."""
+    conn = op.get_bind()
+
+    pipeline_run = sa.table(
+        'pipeline_run',
+        sa.column('id', sa.String),
+        sa.column('root_execution_id', sa.String),
+        sa.column('status', sa.String),
+        sa.column('has_ended', sa.Boolean),
+    )
+    execution_ancestor = sa.table(
+        'execution_ancestor',
+        sa.column('ancestor_execution_id', sa.String),
+        sa.column('execution_id', sa.String),
+    )
+    execution_node = sa.table(
+        'execution_node',
+        sa.column('id', sa.String),
+        sa.column('container_execution_status', sa.String),
+    )
+
+    rows = conn.execute(
+        sa.select(pipeline_run.c.id, pipeline_run.c.root_execution_id)
+        .where(pipeline_run.c.status == None)
+    ).fetchall()
+
+    for run_id, root_execution_id in rows:
+        status_counts = conn.execute(
+            sa.select(
+                execution_node.c.container_execution_status,
+                sa.func.count().label('cnt'),
+            )
+            .select_from(execution_node)
+            .join(
+                execution_ancestor,
+                execution_ancestor.c.execution_id == execution_node.c.id,
+            )
+            .where(execution_ancestor.c.ancestor_execution_id == root_execution_id)
+            .where(execution_node.c.container_execution_status != None)
+            .group_by(execution_node.c.container_execution_status)
+        ).fetchall()
+
+        if not status_counts:
+            continue
+
+        best_priority = 99
+        total = 0
+        ended = 0
+        for status_val, count in status_counts:
+            priority = _STATUS_PRIORITY.get(status_val, 99)
+            if priority < best_priority:
+                best_priority = priority
+            total += count
+            if status_val in _ENDED_STATUSES:
+                ended += count
+
+        computed_status = _PRIORITY_TO_STATUS.get(best_priority)
+        computed_has_ended = total > 0 and ended == total
+
+        conn.execute(
+            pipeline_run.update()
+            .where(pipeline_run.c.id == run_id)
+            .values(status=computed_status, has_ended=computed_has_ended)
+        )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_pipeline_run_status_created_at_desc', table_name='pipeline_run')
+    with op.batch_alter_table('pipeline_run', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_pipeline_run_status'))
+        batch_op.drop_column('has_ended')
+        batch_op.drop_column('status')

--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -137,8 +137,10 @@ class PipelineRun(_TableBase):
     )
     root_execution: orm.Mapped["ExecutionNode"] = orm.relationship(repr=False)
     annotations: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
-    # status: "PipelineJobStatus"
-    # root_execution_summary: "ExecutionSummary"
+    status: orm.Mapped[ContainerExecutionStatus | None] = orm.mapped_column(
+        default=None, index=True
+    )
+    has_ended: orm.Mapped[bool] = orm.mapped_column(default=False)
     created_by: orm.Mapped[str | None] = orm.mapped_column(default=None)
     created_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(default=None)
     updated_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(default=None)
@@ -165,6 +167,11 @@ class PipelineRun(_TableBase):
         sql.Index(
             "ix_pipeline_run_pipeline_name",
             pipeline_name,
+        ),
+        sql.Index(
+            "ix_pipeline_run_status_created_at_desc",
+            status,
+            created_at.desc(),
         ),
     )
 

--- a/cloud_pipelines_backend/database_ops.py
+++ b/cloud_pipelines_backend/database_ops.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import sqlalchemy
 
+from . import backend_types_sql as bts
+
 _logger = logging.getLogger(__name__)
 
 _ALEMBIC_INI_PATH = str(Path(__file__).resolve().parent.parent / "alembic.ini")
@@ -15,25 +17,50 @@ def create_db_engine_and_migrate_db(
 ) -> sqlalchemy.Engine:
     db_engine = create_db_engine(database_uri=database_uri, **kwargs)
     run_migrations(db_engine)
+    _create_unmanaged_tables(db_engine)
     return db_engine
 
 
 def initialize_and_migrate_db(db_engine: sqlalchemy.Engine):
     run_migrations(db_engine)
+    _create_unmanaged_tables(db_engine)
+
+
+def _create_unmanaged_tables(db_engine: sqlalchemy.Engine) -> None:
+    """Create tables not yet tracked by Alembic migrations (e.g. ComponentLibraryRow)."""
+    bts._TableBase.metadata.create_all(db_engine, checkfirst=True)
 
 
 def run_migrations(db_engine: sqlalchemy.Engine) -> None:
     """Run all pending Alembic migrations against the given engine."""
-    from alembic import command
     from alembic.config import Config
+    from alembic.runtime.migration import MigrationContext
+    from alembic.script import ScriptDirectory
 
     alembic_cfg = Config(_ALEMBIC_INI_PATH)
-    alembic_cfg.attributes["connection"] = db_engine
+    script = ScriptDirectory.from_config(alembic_cfg)
 
     _logger.info("Running database migrations")
     with db_engine.connect() as connection:
-        alembic_cfg.attributes["connection"] = connection
-        command.upgrade(alembic_cfg, "head")
+        migration_context = MigrationContext.configure(
+            connection,
+            opts={"target_metadata": None, "render_as_batch": True},
+        )
+        current_rev = migration_context.get_current_revision()
+        head_rev = script.get_current_head()
+
+        if current_rev == head_rev:
+            _logger.info("Database already at head revision")
+        else:
+            _logger.info(
+                f"Migrating from {current_rev} to {head_rev}"
+            )
+
+            from alembic import command
+
+            alembic_cfg.attributes["connection"] = connection
+            command.upgrade(alembic_cfg, "head")
+
     _logger.info("Database migrations complete")
 
 

--- a/cloud_pipelines_backend/status_utils.py
+++ b/cloud_pipelines_backend/status_utils.py
@@ -1,0 +1,124 @@
+"""Utilities for computing and updating the denormalized PipelineRun.status column.
+
+Pipeline run status is the highest-priority ContainerExecutionStatus among all
+descendant execution nodes, using the priority mapping below (lower number wins).
+"""
+
+import logging
+
+import sqlalchemy as sql
+from sqlalchemy import orm
+
+from . import backend_types_sql as bts
+
+_logger = logging.getLogger(__name__)
+
+STATUS_PRIORITY: dict[bts.ContainerExecutionStatus, int] = {
+    bts.ContainerExecutionStatus.SYSTEM_ERROR: 1,
+    bts.ContainerExecutionStatus.FAILED: 2,
+    bts.ContainerExecutionStatus.INVALID: 3,
+    bts.ContainerExecutionStatus.CANCELLING: 4,
+    bts.ContainerExecutionStatus.CANCELLED: 5,
+    bts.ContainerExecutionStatus.RUNNING: 6,
+    bts.ContainerExecutionStatus.PENDING: 7,
+    bts.ContainerExecutionStatus.WAITING_FOR_UPSTREAM: 8,
+    bts.ContainerExecutionStatus.QUEUED: 9,
+    bts.ContainerExecutionStatus.UNINITIALIZED: 10,
+    bts.ContainerExecutionStatus.SKIPPED: 11,
+    bts.ContainerExecutionStatus.SUCCEEDED: 12,
+}
+
+PRIORITY_TO_STATUS: dict[int, bts.ContainerExecutionStatus] = {
+    v: k for k, v in STATUS_PRIORITY.items()
+}
+
+
+def update_pipeline_run_status(
+    session: orm.Session,
+    execution_id: bts.IdType,
+) -> None:
+    """Recompute and persist pipeline run status for the run containing this execution.
+
+    Finds the pipeline run via the execution_ancestor table (or direct root match),
+    then aggregates all descendant execution statuses using the priority system.
+    """
+    pipeline_run = _find_pipeline_run_for_execution(session, execution_id)
+    if pipeline_run is None:
+        return
+
+    _recompute_and_persist_status(session, pipeline_run)
+
+
+def _find_pipeline_run_for_execution(
+    session: orm.Session,
+    execution_id: bts.IdType,
+) -> bts.PipelineRun | None:
+    """Find the pipeline run that owns the given execution node."""
+    # The execution might be the root itself
+    pipeline_run = session.scalar(
+        sql.select(bts.PipelineRun).where(
+            bts.PipelineRun.root_execution_id == execution_id
+        )
+    )
+    if pipeline_run is not None:
+        return pipeline_run
+
+    # Otherwise, look through the ancestor table
+    return session.scalar(
+        sql.select(bts.PipelineRun)
+        .join(
+            bts.ExecutionToAncestorExecutionLink,
+            bts.ExecutionToAncestorExecutionLink.ancestor_execution_id
+            == bts.PipelineRun.root_execution_id,
+        )
+        .where(bts.ExecutionToAncestorExecutionLink.execution_id == execution_id)
+        .limit(1)
+    )
+
+
+def _recompute_and_persist_status(
+    session: orm.Session,
+    pipeline_run: bts.PipelineRun,
+) -> None:
+    """Aggregate descendant execution statuses and update the pipeline run."""
+    rows = (
+        session.execute(
+            sql.select(
+                bts.ExecutionNode.container_execution_status,
+                sql.func.count().label("cnt"),
+            )
+            .join(
+                bts.ExecutionToAncestorExecutionLink,
+                bts.ExecutionToAncestorExecutionLink.execution_id
+                == bts.ExecutionNode.id,
+            )
+            .where(
+                bts.ExecutionToAncestorExecutionLink.ancestor_execution_id
+                == pipeline_run.root_execution_id
+            )
+            .where(bts.ExecutionNode.container_execution_status != None)
+            .group_by(bts.ExecutionNode.container_execution_status)
+        )
+        .tuples()
+        .all()
+    )
+
+    if not rows:
+        return
+
+    best_priority = 99
+    total = 0
+    ended = 0
+    for status, count in rows:
+        priority = STATUS_PRIORITY.get(status, 99)
+        if priority < best_priority:
+            best_priority = priority
+        total += count
+        if status in bts.CONTAINER_STATUSES_ENDED:
+            ended += count
+
+    new_status = PRIORITY_TO_STATUS.get(best_priority)
+    new_has_ended = total > 0 and ended == total
+
+    pipeline_run.status = new_status
+    pipeline_run.has_ended = new_has_ended


### PR DESCRIPTION
### TL;DR

Added denormalized `status` and `has_ended` columns to the `pipeline_run` table to improve query performance and simplify status filtering.

### What changed?

- Added `status` and `has_ended` columns to the `PipelineRun` model with appropriate database indexes
- Created Alembic migration `457e50b9271c` to add the new columns and backfill existing data
- Implemented `status_utils.py` module with functions to compute pipeline run status based on descendant execution node statuses using a priority system
- Updated `PipelineRunResponse` to include the new status fields
- Modified pipeline run creation, termination, and orchestration logic to automatically update status when execution nodes change
- Simplified status filtering in the list API to use the denormalized column instead of complex subqueries
- Enhanced Alembic environment configuration to better handle different connection types

### How to test?

1. Run the database migration to add the new columns and verify existing pipeline runs have correct status values
2. Create new pipeline runs and verify status is computed correctly during execution
3. Test pipeline run listing with status filters to ensure they work with the new denormalized column
4. Verify status updates correctly when executions are terminated or encounter errors
5. Check that `has_ended` flag is set appropriately when all descendant executions reach terminal states

### Why make this change?

The previous implementation computed pipeline run status on-the-fly using complex SQL subqueries that joined multiple tables, which was inefficient for filtering and sorting operations. By denormalizing the status into the `pipeline_run` table and keeping it updated in real-time, we can significantly improve query performance while simplifying the API code. The `has_ended` flag provides additional filtering capabilities for completed pipeline runs.