### PR TITLE
Adds migrations - annotation index migration

### DIFF
--- a/alembic/versions/a1f3c8d92e47_add_annotation_key_value_index.py
+++ b/alembic/versions/a1f3c8d92e47_add_annotation_key_value_index.py
@@ -1,0 +1,32 @@
+"""Add annotation key+value index for filter queries
+
+Revision ID: a1f3c8d92e47
+Revises: 457e50b9271c
+Create Date: 2026-02-21
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a1f3c8d92e47"
+down_revision: Union[str, None] = "457e50b9271c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_pipeline_run_annotation_key_value",
+        "pipeline_run_annotation",
+        ["key", "value"],
+        unique=False,
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_pipeline_run_annotation_key_value",
+        table_name="pipeline_run_annotation",
+    )

--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -513,6 +513,14 @@ class PipelineRunAnnotation(_TableBase):
     key: orm.Mapped[str] = orm.mapped_column(default=None, primary_key=True)
     value: orm.Mapped[str | None] = orm.mapped_column(default=None)
 
+    __table_args__ = (
+        sql.Index(
+            "ix_pipeline_run_annotation_key_value",
+            key,
+            value,
+        ),
+    )
+
 
 class Secret(_TableBase):
     __tablename__ = "secret"


### PR DESCRIPTION
### TL;DR

Added a composite database index on the `key` and `value` columns of the `pipeline_run_annotation` table to improve query performance.

### What changed?

- Created a new Alembic migration that adds a composite index `ix_pipeline_run_annotation_key_value` on the `pipeline_run_annotation` table
- Updated the `PipelineRunAnnotation` SQLAlchemy model to include the composite index definition in `__table_args__`
- The index covers both `key` and `value` columns to optimize filter queries that search on annotation key-value pairs

### How to test?

- Run the Alembic migration to apply the database schema change
- Verify the index exists in the database by checking the `pipeline_run_annotation` table indexes
- Test annotation filter queries to confirm improved performance
- Ensure the migration can be rolled back successfully using the downgrade function

### Why make this change?

This change optimizes database performance for filter queries that search pipeline run annotations by key and value combinations. The composite index will significantly speed up queries that filter annotations based on both key and value criteria, which is likely a common access pattern in the application.