### PR TITLE
Adds N+1 tests

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -80,13 +80,7 @@ def run_migrations_online() -> None:
         with context.begin_transaction():
             context.run_migrations()
 
-    try:
-        connectable.connect
-        is_engine = hasattr(connectable, "pool")
-    except AttributeError:
-        is_engine = False
-
-    if is_engine:
+    if isinstance(connectable, sa.engine.Engine):
         with connectable.connect() as connection:
             _run_with_connection(connection)
     else:

--- a/cloud_pipelines_backend/api_router.py
+++ b/cloud_pipelines_backend/api_router.py
@@ -13,7 +13,6 @@ import starlette.types
 from . import api_server_sql
 from . import backend_types_sql
 from . import component_library_api_server as components_api
-from . import database_ops
 from . import errors
 from .instrumentation import contextual_logging
 
@@ -45,10 +44,6 @@ def setup_routes(
             yield session
 
     def create_db_and_tables():
-        database_ops.initialize_and_migrate_db(db_engine=db_engine)
-
-        # The default library must be initialized here, not when adding the Component Library routes.
-        # Otherwise the tables won't yet exist when initialization is performed.
         component_library_service = components_api.ComponentLibraryService()
         with orm.Session(bind=db_engine) as session:
             component_library_service._initialize_empty_default_library_if_missing(

--- a/cloud_pipelines_backend/query_tracker.py
+++ b/cloud_pipelines_backend/query_tracker.py
@@ -1,0 +1,163 @@
+"""SQLAlchemy query tracker for detecting N+1 query patterns.
+
+Usage as a context manager:
+
+    with QueryTracker(engine) as tracker:
+        service.list(session=session, ...)
+
+    tracker.assert_no_n_plus_one(threshold=5)
+
+Or with automatic assertion:
+
+    with QueryTracker(engine, n_plus_one_threshold=5):
+        service.list(session=session, ...)
+"""
+
+from __future__ import annotations
+
+import re
+import textwrap
+from collections import Counter
+from dataclasses import dataclass, field
+
+import sqlalchemy
+from sqlalchemy import event
+
+
+_PARAM_PATTERNS = [
+    re.compile(r"'[^']*'"),
+    re.compile(r"\b\d+\b"),
+    re.compile(r"\?"),
+]
+
+
+def _normalize_sql(sql: str) -> str:
+    """Normalize a SQL statement for grouping: collapse params, whitespace."""
+    normalized = sql.strip()
+    for pattern in _PARAM_PATTERNS:
+        normalized = pattern.sub("?", normalized)
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized
+
+
+@dataclass
+class QueryRecord:
+    sql: str
+    normalized: str
+    parameters: object = None
+
+
+@dataclass
+class NPlusOneViolation:
+    normalized_sql: str
+    count: int
+    example_sql: str
+
+
+@dataclass
+class QueryTracker:
+    """Track SQL queries on a SQLAlchemy engine and detect N+1 patterns."""
+
+    engine: sqlalchemy.Engine
+    n_plus_one_threshold: int | None = None
+    queries: list[QueryRecord] = field(default_factory=list, init=False)
+    _listening: bool = field(default=False, init=False)
+
+    def _on_before_execute(
+        self, conn, cursor, statement, parameters, context, executemany
+    ):
+        record = QueryRecord(
+            sql=statement,
+            normalized=_normalize_sql(statement),
+            parameters=parameters,
+        )
+        self.queries.append(record)
+
+    def start(self) -> None:
+        if self._listening:
+            return
+        event.listen(
+            self.engine, "before_cursor_execute", self._on_before_execute
+        )
+        self._listening = True
+
+    def stop(self) -> None:
+        if not self._listening:
+            return
+        event.remove(
+            self.engine, "before_cursor_execute", self._on_before_execute
+        )
+        self._listening = False
+
+    def reset(self) -> None:
+        self.queries.clear()
+
+    @property
+    def query_count(self) -> int:
+        return len(self.queries)
+
+    def get_pattern_counts(self) -> Counter[str]:
+        return Counter(q.normalized for q in self.queries)
+
+    def find_n_plus_one(
+        self, threshold: int = 5, selects_only: bool = False
+    ) -> list[NPlusOneViolation]:
+        """Find query patterns that repeat more than `threshold` times.
+
+        Args:
+            threshold: A pattern must repeat more than this many times.
+            selects_only: When True, only consider SELECT statements. Useful for
+                auto-detection where INSERT/UPDATE from test setup would be
+                false positives.
+        """
+        queries = self.queries
+        if selects_only:
+            queries = [q for q in queries if q.normalized.upper().startswith("SELECT")]
+
+        counts: Counter[str] = Counter(q.normalized for q in queries)
+        example_map: dict[str, str] = {}
+        for q in queries:
+            if q.normalized not in example_map:
+                example_map[q.normalized] = q.sql
+
+        return [
+            NPlusOneViolation(
+                normalized_sql=pattern,
+                count=count,
+                example_sql=example_map[pattern],
+            )
+            for pattern, count in counts.most_common()
+            if count > threshold
+        ]
+
+    def assert_no_n_plus_one(self, threshold: int = 5) -> None:
+        """Raise AssertionError if any query pattern exceeds the threshold."""
+        violations = self.find_n_plus_one(threshold)
+        if violations:
+            parts = [
+                f"Detected {len(violations)} N+1 query pattern(s) "
+                f"(threshold={threshold}):\n"
+            ]
+            for v in violations:
+                parts.append(
+                    f"  [{v.count}x] {textwrap.shorten(v.normalized_sql, 120)}\n"
+                    f"        example: {textwrap.shorten(v.example_sql, 120)}\n"
+                )
+            raise AssertionError("".join(parts))
+
+    def summary(self) -> str:
+        """Human-readable summary of captured queries."""
+        counts = self.get_pattern_counts()
+        lines = [f"Total queries: {self.query_count}"]
+        for pattern, count in counts.most_common():
+            lines.append(f"  [{count:>3}x] {textwrap.shorten(pattern, 100)}")
+        return "\n".join(lines)
+
+    def __enter__(self) -> QueryTracker:
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.stop()
+        if exc_type is None and self.n_plus_one_threshold is not None:
+            self.assert_no_n_plus_one(self.n_plus_one_threshold)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+import sqlalchemy
+from sqlalchemy import orm
+
+from cloud_pipelines_backend import database_ops
+from cloud_pipelines_backend.query_tracker import QueryTracker
+
+N_PLUS_ONE_THRESHOLD = 5
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "allow_n_plus_one: disable the requirement to use query_tracker in this test",
+    )
+
+
+@pytest.fixture
+def db_engine() -> sqlalchemy.Engine:
+    """Create a fresh in-memory SQLite engine with all migrations applied."""
+    return database_ops.create_db_engine_and_migrate_db(database_uri="sqlite://")
+
+
+@pytest.fixture
+def session_factory(db_engine: sqlalchemy.Engine) -> Callable[[], orm.Session]:
+    return lambda: orm.Session(bind=db_engine)
+
+
+@pytest.fixture
+def session(db_engine: sqlalchemy.Engine) -> orm.Session:
+    return orm.Session(bind=db_engine)
+
+
+@pytest.fixture
+def query_tracker(db_engine: sqlalchemy.Engine) -> QueryTracker:
+    """Provides a QueryTracker bound to the test's db engine.
+
+    Usage:
+        def test_something(query_tracker, session):
+            with query_tracker:
+                service.list(session=session)
+            query_tracker.assert_no_n_plus_one(threshold=5)
+    """
+    return QueryTracker(engine=db_engine)
+
+
+@pytest.fixture(autouse=True)
+def _require_n_plus_one_coverage(request: pytest.FixtureRequest) -> None:
+    """Enforce that every DB test either checks for N+1 or explicitly opts out.
+
+    Any test using db_engine / session / session_factory must also request the
+    ``query_tracker`` fixture OR be marked with ``@pytest.mark.allow_n_plus_one``.
+    This prevents new code paths from silently skipping N+1 coverage.
+    """
+    yield
+
+    uses_db = any(
+        name in request.fixturenames
+        for name in ("db_engine", "session", "session_factory")
+    )
+    if not uses_db:
+        return
+
+    if request.node.get_closest_marker("allow_n_plus_one"):
+        return
+
+    if "query_tracker" in request.fixturenames:
+        return
+
+    pytest.fail(
+        "This test uses a database but has no N+1 query protection.\n"
+        "Either:\n"
+        "  1. Add the 'query_tracker' fixture and wrap your code under test with:\n"
+        "       with query_tracker:\n"
+        "           service.your_method(session=session)\n"
+        "       query_tracker.assert_no_n_plus_one(threshold=5)\n"
+        "  2. Add @pytest.mark.allow_n_plus_one to opt out\n"
+    )

--- a/tests/test_n_plus_one.py
+++ b/tests/test_n_plus_one.py
@@ -1,0 +1,259 @@
+"""N+1 query detection tests.
+
+These tests create realistic data and exercise the main API code paths,
+asserting that the number of repeated query patterns stays below a threshold.
+A failure here means a code path is issuing the same query once per row
+instead of batching -- the classic N+1 problem.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+import sqlalchemy as sql
+from sqlalchemy import orm
+
+from cloud_pipelines_backend import api_server_sql, backend_types_sql as bts, component_structures as cs
+from cloud_pipelines_backend.query_tracker import QueryTracker
+
+N_PLUS_ONE_THRESHOLD = 5
+NUM_PIPELINE_RUNS = 10
+
+
+def _make_simple_task(name: str) -> cs.TaskSpec:
+    """Create a minimal single-container pipeline task."""
+    component = cs.ComponentSpec(
+        name=name,
+        implementation=cs.ContainerImplementation(
+            container=cs.ContainerSpec(image="python:3.12"),
+        ),
+    )
+    return cs.TaskSpec(
+        component_ref=cs.ComponentReference(spec=component),
+    )
+
+
+def _make_graph_task(name: str, num_children: int = 3) -> cs.TaskSpec:
+    """Create a graph pipeline with multiple child tasks."""
+    child_tasks = {}
+    for i in range(num_children):
+        child_component = cs.ComponentSpec(
+            name=f"{name}-step-{i}",
+            implementation=cs.ContainerImplementation(
+                container=cs.ContainerSpec(image="python:3.12"),
+            ),
+        )
+        child_tasks[f"step_{i}"] = cs.TaskSpec(
+            component_ref=cs.ComponentReference(spec=child_component),
+        )
+
+    graph_component = cs.ComponentSpec(
+        name=name,
+        implementation=cs.GraphImplementation(
+            graph=cs.GraphSpec(tasks=child_tasks),
+        ),
+    )
+    return cs.TaskSpec(
+        component_ref=cs.ComponentReference(spec=graph_component),
+    )
+
+
+def _seed_pipeline_runs(
+    session_factory: Callable[[], orm.Session],
+    service: api_server_sql.PipelineRunsApiService_Sql,
+    count: int = NUM_PIPELINE_RUNS,
+) -> list[api_server_sql.PipelineRunResponse]:
+    """Create multiple pipeline runs with varied data."""
+    runs = []
+    for i in range(count):
+        task = _make_graph_task(f"pipeline-{i}", num_children=3)
+        response = service.create(
+            session=session_factory(),
+            root_task=task,
+            created_by=f"user-{i % 3}",
+            annotations={"env": "test", "run_index": str(i)},
+        )
+        runs.append(response)
+
+        service.set_annotation(
+            session=session_factory(),
+            id=response.id,
+            key="team",
+            value=f"team-{i % 2}",
+            user_name=f"user-{i % 3}",
+        )
+    return runs
+
+
+class TestNPlusOneListPipelineRuns:
+    """Ensure listing pipeline runs doesn't degrade into per-row queries."""
+
+    def test_list_no_extras(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(session=session_factory())
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_list_with_pipeline_names(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                include_pipeline_names=True,
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_list_with_execution_stats(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                include_execution_stats=True,
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_list_with_all_extras(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                include_pipeline_names=True,
+                include_execution_stats=True,
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+
+class TestNPlusOneFilters:
+    """Ensure filter queries don't cause per-row lookups."""
+
+    def test_filter_by_status(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                filter="status:UNINITIALIZED",
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_filter_by_created_by(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                filter="created_by:user-0",
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_filter_by_pipeline_name(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                filter="pipeline_name:pipeline",
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_filter_by_annotation(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        with query_tracker:
+            service.list(
+                session=session_factory(),
+                filter="annotation:team=team-0",
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+
+class TestNPlusOneGetEndpoints:
+    """Ensure individual get endpoints don't cause cascading queries."""
+
+    def test_get_pipeline_run(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        runs = _seed_pipeline_runs(session_factory, service, count=1)
+
+        with query_tracker:
+            service.get(session=session_factory(), id=runs[0].id)
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+    def test_get_execution_node(self, session_factory, query_tracker):
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        runs = _seed_pipeline_runs(session_factory, service, count=1)
+
+        exec_service = api_server_sql.ExecutionNodesApiService_Sql()
+        with query_tracker:
+            exec_service.get(
+                session=session_factory(), id=runs[0].root_execution_id
+            )
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+
+class TestQueryTrackerDetection:
+    """Verify the tracker actually catches N+1 patterns (sanity check)."""
+
+    @pytest.mark.allow_n_plus_one
+    def test_deliberate_n_plus_one_is_detected(self, session_factory, query_tracker):
+        """A loop that queries per row must trigger an assertion."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service)
+
+        session = session_factory()
+        runs = session.execute(sql.select(bts.PipelineRun)).scalars().all()
+
+        with query_tracker:
+            for run in runs:
+                session.execute(
+                    sql.select(bts.ExecutionNode).where(
+                        bts.ExecutionNode.id == run.root_execution_id
+                    )
+                )
+
+        with pytest.raises(AssertionError, match="N\\+1 query pattern"):
+            query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)
+
+
+class TestGuardCatchesMissingTracker:
+    """Demonstrate that CI fails when a DB test skips N+1 coverage.
+
+    DELETE THIS CLASS once you've seen it in action.
+    """
+
+    # def test_missing_tracker_fails(self, session_factory):
+    #     """Uses the DB but has no query_tracker -- the guard will fail this at teardown."""
+    #     service = api_server_sql.PipelineRunsApiService_Sql()
+    #     _seed_pipeline_runs(session_factory, service, count=1)
+
+    def test_with_tracker_passes(self, session_factory, query_tracker):
+        """Same test but with query_tracker -- the guard is satisfied."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        _seed_pipeline_runs(session_factory, service, count=3)
+
+        with query_tracker:
+            service.list(session=session_factory())
+
+        query_tracker.assert_no_n_plus_one(threshold=N_PLUS_ONE_THRESHOLD)


### PR DESCRIPTION
### TL;DR

Added N+1 query detection infrastructure and optimized pipeline run listing to prevent performance degradation with large datasets.

### What changed?

- **Added QueryTracker utility** - New `query_tracker.py` module that monitors SQLAlchemy queries and detects N+1 patterns where the same query executes repeatedly
- **Optimized execution stats calculation** - Replaced per-pipeline-run queries with a single batch query in `_calculate_execution_status_stats_batch()` method
- **Enhanced database configuration** - Added SQLite timeout settings and WAL mode for better concurrency
- **Improved Alembic migration handling** - Simplified engine type detection and connection management
- **Added comprehensive test coverage** - New test suite in `test_n_plus_one.py` validates that API endpoints don't exhibit N+1 behavior
- **Enforced N+1 testing** - Added pytest fixture that requires all database tests to either use query tracking or explicitly opt out

### How to test?

Run the new N+1 detection tests:
```bash
pytest tests/test_n_plus_one.py -v
```

The tests create realistic pipeline data and verify that listing operations don't degrade into per-row queries. The `QueryTracker` can also be used manually:

```python
with QueryTracker(engine) as tracker:
    service.list(session=session)
tracker.assert_no_n_plus_one(threshold=5)
```

### Why make this change?

N+1 queries are a common performance anti-pattern where listing N items triggers N+1 database queries instead of a few efficient batch queries. This becomes critical as datasets grow - what works fine with 10 pipeline runs can timeout with 1000. The changes ensure the API maintains consistent performance regardless of data volume and provides tooling to catch regressions early in development.