### PR TITLE
Removes dead code and comments that are not needed

### DIFF
--- a/cloud_pipelines_backend/api_router.py
+++ b/cloud_pipelines_backend/api_router.py
@@ -196,8 +196,6 @@ def _setup_routes_internal(
         ensure_user_can_write_dependency,
     ]
 
-    # === API ===
-
     router = fastapi.APIRouter(
         lifespan=lifespan,
     )
@@ -533,29 +531,7 @@ def _setup_routes_internal(
     ) -> str:
         return session.get_bind().pool.status()
 
-    # # Needs to be called after all routes have been added to the router
-    # app.include_router(router)
-
     app.include_router(router=router)
-
-
-# def partial_wraps(func, **kwargs):
-#     import inspect
-#
-#     # return functools.wraps(func)(functools.partial(func, *args, **kwargs))
-#     partial_func = functools.partial(func, **kwargs)
-#     param_names = set(kwargs)
-#     signature = inspect.signature(func)
-#     partial_signature = signature.replace(
-#         parameters=[
-#             parameter
-#             for parameter_name, parameter in signature.parameters.items()
-#             if parameter_name not in param_names
-#         ]
-#     )
-#     print(f"{partial_signature=}")
-#     partial_func.__signature__ = partial_signature
-#     return partial_func
 
 
 # Super hack to avoid duplicating functions in Fast API

--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -12,24 +12,17 @@ IdType: typing.TypeAlias = str
 
 
 class ContainerExecutionStatus(str, enum.Enum):
-    INVALID = "INVALID"  # Compatibility with Vertex AI CustomJob
-    UNINITIALIZED = "UNINITIALIZED"  # Remove
-    QUEUED = "QUEUED"  # Before WAITING_FOR_UPSTREAM or STARTING
-    # READY_TO_START = "READY_TO_START"  # Input artifacts ready, but no job ID
+    INVALID = "INVALID"
+    UNINITIALIZED = "UNINITIALIZED"
+    QUEUED = "QUEUED"
     WAITING_FOR_UPSTREAM = "WAITING_FOR_UPSTREAM"
-    # STARTING = "STARTING"
-    PENDING = "PENDING"  # == Starting
+    PENDING = "PENDING"
     RUNNING = "RUNNING"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
-    # UPSTREAM_FAILED = "UPSTREAM_FAILED"
-    # CONDITIONALLY_SKIPPED = "CONDITIONALLY_SKIPPED"
     SYSTEM_ERROR = "SYSTEM_ERROR"
-
-    # new
     CANCELLING = "CANCELLING"
     CANCELLED = "CANCELLED"
-    # UPSTREAM_FAILED_OR_SKIPPED = "UPSTREAM_FAILED_OR_SKIPPED"
     SKIPPED = "SKIPPED"
 
 
@@ -61,19 +54,6 @@ def generate_unique_id() -> str:
 id_column = orm.mapped_column(
     sql.String(20), primary_key=True, init=False, insert_default=generate_unique_id
 )
-
-# # Needed to put a union type into DB
-# class SqlIOTypeStruct(_BaseModel):
-#     type: structures.TypeSpecType
-# No. We'll represent TypeSpecType as name:str + properties:dict
-# Supported cases:
-# * type: "name"
-# * type: {"name": {...}}
-# We drop support for following cases:
-# * `type: [...]`
-# * `type: {"a": ..., "b": ...}`cases
-# If needed they can be represented using `weirdType: ...`
-
 
 class UtcDateTime(sql.TypeDecorator):
     """A DateTime type that ensures UTC timezone on read.
@@ -131,21 +111,14 @@ class PipelineRun(_TableBase):
     id: orm.Mapped[IdType] = orm.mapped_column(
         primary_key=True, init=False, insert_default=generate_unique_id
     )
-    # pipeline_spec: orm.Mapped[dict[str, Any]]
     root_execution_id: orm.Mapped[IdType] = orm.mapped_column(
         sql.ForeignKey("execution_node.id"), init=False
     )
     root_execution: orm.Mapped["ExecutionNode"] = orm.relationship(repr=False)
     annotations: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
-    # status: "PipelineJobStatus"
-    # root_execution_summary: "ExecutionSummary"
     created_by: orm.Mapped[str | None] = orm.mapped_column(default=None)
     created_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(default=None)
     updated_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(default=None)
-    # start_time: datetime.datetime | None = None
-    # end_time: datetime.datetime | None = None
-    # For version control. We can calculate diff and draw a pipeline evolution graph.
-    # Can be stored in annotations though.
     parent_pipeline_id: orm.Mapped[IdType | None] = orm.mapped_column(default=None)
 
     extra_data: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
@@ -184,10 +157,6 @@ class ArtifactData(_TableBase):
 
     extra_data: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
 
-    # artifact_nodes: orm.Mapped[list["ArtifactNode"]] = orm.relationship(
-    #     default=None, repr=False, back_populates="artifact_data"
-    # )
-
 
 class ArtifactNode(_TableBase):
     __tablename__ = "artifact_node"
@@ -196,20 +165,16 @@ class ArtifactNode(_TableBase):
     )
     had_data_in_past: orm.Mapped[bool] = orm.mapped_column(default=False)
     may_have_data_in_future: orm.Mapped[bool] = orm.mapped_column(default=True)
-    # artifact_type: orm.Mapped[structures.TypeSpecType | None]
     type_name: orm.Mapped[str | None] = orm.mapped_column(default=None)
     type_properties: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
-    # producer: ExecutionOutputArtifactSource | None = None
     producer_execution_id: orm.Mapped[IdType | None] = orm.mapped_column(
         sql.ForeignKey("execution_node.id"), init=False
     )
     producer_execution: orm.Mapped["ExecutionNode | None"] = orm.relationship(
-        # back_populates="output_artifacts",
         default=None,
         repr=False,
     )
     producer_output_name: orm.Mapped[str | None] = orm.mapped_column(default=None)
-    # artifact_data: ArtifactData | None = None
     artifact_data_id: orm.Mapped[IdType | None] = orm.mapped_column(
         sql.ForeignKey("artifact_data.id"), init=False
     )
@@ -227,10 +192,6 @@ class ArtifactNode(_TableBase):
         secondary="input_artifact_link", viewonly=True, default_factory=list, repr=False
     )
 
-    # x_producer_execution_output_link_id: orm.Mapped[IdType | None]
-    # x_producer_execution_output_link: orm.Mapped["SqlOutputArtifactLink | None"] = (
-    #     orm.relationship(back_populates="artifact")
-    # )
     extra_data: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
 
 
@@ -250,7 +211,6 @@ class InputArtifactLink(_TableBase):
     artifact: orm.Mapped[ArtifactNode] = orm.relationship(
         back_populates="downstream_execution_links"
     )
-    # Should we include artifact node status here?
 
 
 class OutputArtifactLink(_TableBase):
@@ -269,7 +229,6 @@ class OutputArtifactLink(_TableBase):
     artifact: orm.Mapped[ArtifactNode] = orm.relationship(
         back_populates="upstream_execution_links"
     )
-    # Should we include artifact node status here?
 
 
 class ExecutionToAncestorExecutionLink(_TableBase):
@@ -297,16 +256,7 @@ class ExecutionNode(_TableBase):
     id: orm.Mapped[IdType] = orm.mapped_column(
         primary_key=True, init=False, insert_default=generate_unique_id
     )
-    # input_artifacts
-    # task_id: str | None = None
-    # task_spec: structures.TaskSpec
-    # task_spec: orm.Mapped[structures.TaskSpec]
     task_spec: orm.Mapped[dict[str, Any]]
-    # input_arguments: dict[str, ArtifactNode]
-
-    # constant_arguments: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(
-    #     default=None
-    # )  # dict[str, ArtifactData]
 
     input_artifact_links: orm.Mapped[list[InputArtifactLink]] = orm.relationship(
         back_populates="execution",
@@ -314,8 +264,6 @@ class ExecutionNode(_TableBase):
         default_factory=list,
         repr=False,
     )
-    # outputs: dict[str, ArtifactNode]
-    # output_artifacts: dict[str, ArtifactNodeWithOptionalId]  # Or should we use IDs?
     output_artifact_links: orm.Mapped[list[OutputArtifactLink]] = orm.relationship(
         back_populates="execution",
         init=False,
@@ -343,7 +291,6 @@ class ExecutionNode(_TableBase):
         default=None,
         repr=False,
     )
-    # parent_execution: "SqlExecutionNode" = sqlmodel.Relationship()
     child_executions: orm.Mapped[list["ExecutionNode"]] = orm.relationship(
         remote_side=[parent_execution_id],
         back_populates="parent_execution",
@@ -352,26 +299,6 @@ class ExecutionNode(_TableBase):
         repr=False,
     )
 
-    # updated_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(default=None)
-
-    # execution_kind = orm.Mapped[typing.Literal["CONTAINER", "GRAPH"]]
-
-    # Graph nodes only
-    # child_task_execution_nodes: dict[str, "ExecutionNode"] | None = None
-    # child_task_execution_node_ids: dict[str, str] | None = None
-    # graph_execution_details: GraphExecutionDetails | None = None
-    # graph_execution_details__child_task_execution_node_ids: dict[str, str]
-    # graph_execution_details__child_task_execution_links: list["SqlExecutionToChildExecutionLink"] = sqlmodel.Relationship(back_populates="parent_execution_id")
-    # graph_execution_details__child_task_execution_nodes: list["SqlExecutionNode"] = sqlmodel.Relationship()
-    # graph_execution_details__child_execution_summaries: dict[str, ExecutionSummary]
-
-    # Container nodes only
-    # container_execution_id: str | None = None
-    # container_execution_details: ContainerExecutionDetails | None = None
-    # container_execution_details__status: ContainerExecutionStatus
-    # container_execution_details__container_execution_id: orm.Mapped[IdType | None]
-    # container_execution_details__last_processed_time: datetime.datetime | None = None
-    # container_execution_details__cache_key: str | None = None
     container_execution_id: orm.Mapped[IdType | None] = orm.mapped_column(
         sql.ForeignKey("container_execution.id"), default=None, init=False
     )
@@ -385,17 +312,6 @@ class ExecutionNode(_TableBase):
     container_execution_cache_key: orm.Mapped[str | None] = orm.mapped_column(
         index=True, default=None
     )
-
-    # ? UX-only de-normalized
-    # For breadcrumbs navigation
-    # parent_execution_node_ids: list[str] | None = None
-    # For breadcrumbs navigation
-    # parent_task_ids: list[str] | None = None
-
-    # ! Cannot have pipeline_run_id foreign key since it will cause circular referencing with PipelineJob
-    # pipeline_run_id: orm.Mapped[IdType | None] = orm.mapped_column(
-    #     sql.ForeignKey("pipeline_run.id")
-    # )
 
     extra_data: orm.Mapped[dict[str, Any] | None] = orm.mapped_column(default=None)
 
@@ -434,25 +350,11 @@ CONTAINER_EXECUTION_EXTRA_DATA_ORCHESTRATION_ERROR_MESSAGE_KEY = (
 )
 
 
-# Not needed. We can use the ExecutionToAncestorExecutionLink.ancestor_execution_id == PipelineRun.root_execution_id
-# class ExecutionToPipelineRunLink(_TableBase):
-#     __tablename__ = "execution_pipeline_run"
-#     execution_id: orm.Mapped[IdType] = orm.mapped_column(
-#         sql.ForeignKey("execution_node.id"), primary_key=True, init=False
-#     )
-#     pipeline_run_id: orm.Mapped[IdType] = orm.mapped_column(
-#         sql.ForeignKey("pipeline_run.id"), primary_key=True, init=False
-#     )
-#     execution: orm.Mapped["ExecutionNode"] = orm.relationship()
-#     pipeline_run: orm.Mapped["PipelineRun"] = orm.relationship()
-
-
 class ContainerExecution(_TableBase):
     __tablename__ = "container_execution"
     id: orm.Mapped[IdType] = orm.mapped_column(
         primary_key=True, init=False, insert_default=generate_unique_id
     )
-    # task_spec: orm.Mapped[dict[str, Any]]
     status: orm.Mapped[ContainerExecutionStatus] = orm.mapped_column(index=True)
     last_processed_at: orm.Mapped[datetime.datetime | None] = orm.mapped_column(
         default=None

--- a/cloud_pipelines_backend/component_library_api_server.py
+++ b/cloud_pipelines_backend/component_library_api_server.py
@@ -88,18 +88,6 @@ class ListComponentsResponse:
 
 # This service probably should not be exposed directly to the API
 class ComponentService:
-    def _list(
-        self, *, session: orm.Session, name_substring: str | None = None
-    ) -> ListComponentsResponse:
-        query = sql.select(ComponentRow)
-        component_rows = session.scalars(query).all()
-        return ListComponentsResponse(
-            components=[
-                ComponentResponse.from_db(component_row)
-                for component_row in component_rows
-            ]
-        )
-
     def get(self, *, session: orm.Session, digest: str) -> ComponentResponse:
         component_row = session.get(ComponentRow, digest)
         if not component_row:

--- a/cloud_pipelines_backend/launchers/interfaces.py
+++ b/cloud_pipelines_backend/launchers/interfaces.py
@@ -73,14 +73,6 @@ class ContainerStatus(str, enum.Enum):
 
 class LaunchedContainer(abc.ABC):
 
-    # @classmethod
-    # def get(cls: typing.Type[_TLaunchedContainer]) -> _TLaunchedContainer:
-    #     raise NotImplementedError()
-
-    # @property
-    # def id(self) -> str:
-    #     raise NotImplementedError()
-
     @property
     def status(self) -> ContainerStatus:
         raise NotImplementedError()
@@ -136,12 +128,3 @@ class LaunchedContainer(abc.ABC):
 
     def terminate(self) -> None:
         raise NotImplementedError()
-
-
-# @dataclasses.dataclass
-# class ContainerExecutionResult:
-#     start_time: datetime.datetime
-#     end_time: datetime.datetime
-#     exit_code: int
-#     # TODO: Replace with logs_artifact
-#     ### log: "ProcessLog"

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -674,10 +674,6 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
             return None
         return state.terminated
 
-    # @property
-    # def id(self) -> str:
-    #     return self.pod_name
-
     @property
     def status(self) -> interfaces.ContainerStatus:
         phase_str = self._debug_pod.status.phase
@@ -1419,8 +1415,6 @@ def _update_dict_recursively(d1: dict, d2: dict):
             if isinstance(v1, dict) and isinstance(v2, dict):
                 _update_dict_recursively(v1, v2)
                 continue
-            # elif isinstance(v1, list) and isinstance(v2, list):
-            # # Merging lists is not supported yet
         d1[k] = v2
 
 

--- a/cloud_pipelines_backend/launchers/local_docker_launchers.py
+++ b/cloud_pipelines_backend/launchers/local_docker_launchers.py
@@ -42,9 +42,6 @@ def _construct_docker_volume_mount(
         raise ValueError(
             f"When creating a mount, container path must be absolute, but got {container_path}."
         )
-    # Maybe it's OK to allow relative paths. (To enable portable self-contained local DB+data directory.)
-    # if not host_path_obj.is_absolute():
-    #     raise ValueError(f"When creating a mount, host path must be absolute, but got {host_path_obj}.")
     host_path_obj = host_path_obj.resolve()
     if container_path_obj.name != host_path_obj.name:
         raise interfaces.LauncherError(
@@ -87,8 +84,6 @@ class DockerContainerLauncher(
         annotations: dict[str, Any] | None = None,
     ) -> "LaunchedDockerContainer":
         container_spec = component_spec.implementation.container
-        input_names = list(input_arguments.keys())
-        output_names = list(output_uris.keys())
 
         # TODO: Validate the output URIs. Don't forget about (`C:\*` and `C:/*` paths)
 

--- a/start_local.py
+++ b/start_local.py
@@ -162,19 +162,6 @@ def run_orchestrator(
     logs_root_uri: str,
     sleep_seconds_between_queue_sweeps: float = 1.0,
 ):
-    # logger = logging.getLogger(__name__)
-    # orchestrator_logger = logging.getLogger("cloud_pipelines_backend.orchestrator_sql")
-
-    # orchestrator_logger.setLevel(logging.DEBUG)
-    # formatter = logging.Formatter("%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
-
-    # stderr_handler = logging.StreamHandler()
-    # stderr_handler.setLevel(logging.INFO)
-    # stderr_handler.setFormatter(formatter)
-
-    # # TODO: Disable the default logger instead of not adding a new one
-    # # orchestrator_logger.addHandler(stderr_handler)
-    # logger.addHandler(stderr_handler)
 
     logger.info("Starting the orchestrator")
 


### PR DESCRIPTION
### TL;DR

Removed commented-out code, unused imports, and dead code across the codebase to improve maintainability and readability.

### What changed?

- Removed extensive commented-out code blocks throughout the backend modules
- Eliminated unused class definitions like `GetPipelineRunResponse` and `_list` method in `ComponentService`
- Cleaned up unused type variables, imports, and function definitions
- Removed dead code paths and obsolete implementation attempts
- Stripped out debugging comments and old API design remnants
- Removed unused method `_maybe_preload_value` and associated constants
- Eliminated unused helper functions like `_assert_type` and `_sqlalchemy_object_to_dict`

### How to test?

Run the existing test suite to ensure no functionality was broken by the cleanup. The application should behave identically to before since only dead code was removed.

### Why make this change?

This cleanup improves code maintainability by removing clutter that makes the codebase harder to navigate and understand. Removing commented-out code and unused definitions reduces cognitive load for developers and eliminates potential confusion about which code paths are actually active.