### PR TITLE
Update import order

### DIFF
--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -1,6 +1,8 @@
 import dataclasses
 import datetime
 import enum
+import os
+import time
 import typing
 from typing import Any
 
@@ -48,9 +50,6 @@ def generate_unique_id() -> str:
 
     The ID is 6 bytes of millisecond-precision time plus 4 random bytes.
     """
-    import os
-    import time
-
     random_bytes = os.urandom(4)
     nanoseconds = time.time_ns()
     milliseconds = nanoseconds // 1_000_000

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import pprint
 import typing
 from typing import Any, Optional
 
@@ -832,8 +833,6 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
             yield str(line) + "\n"
 
     def __str__(self) -> str:
-        import pprint
-
         return pprint.pformat(self.to_dict())
 
     def terminate(self):
@@ -1333,8 +1332,6 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
             yield str(line) + "\n"
 
     def __str__(self) -> str:
-        import pprint
-
         return pprint.pformat(self.to_dict())
 
     def terminate(self):

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -1,7 +1,9 @@
 import copy
-import json
 import datetime
+import hashlib
+import json
 import logging
+import os
 import time
 import traceback
 import typing
@@ -945,8 +947,6 @@ def _assert_not_none(value: _T | None) -> _T:
 
 
 def _calculate_hash(s: str) -> str:
-    import hashlib
-
     return "md5=" + hashlib.md5(s.encode("utf-8")).hexdigest()
 
 
@@ -975,9 +975,6 @@ def _get_current_time() -> datetime.datetime:
 
 
 def _generate_random_id() -> str:
-    import os
-    import time
-
     random_bytes = os.urandom(4)
     nanoseconds = time.time_ns()
     milliseconds = nanoseconds // 1_000_000

--- a/tests/test_instrumentation_request_middleware.py
+++ b/tests/test_instrumentation_request_middleware.py
@@ -1,5 +1,7 @@
 """Tests for the request_middleware module in instrumentation."""
 
+import logging
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from starlette.requests import Request
@@ -253,8 +255,6 @@ class TestRequestContextMiddlewareIntegration:
 
     def test_middleware_enables_request_id_in_logs(self):
         """Test that middleware enables request_id to be used in logging."""
-        import logging
-
         app = Starlette()
         app.add_middleware(RequestContextMiddleware)
 

--- a/tests/test_request_id_concurrency.py
+++ b/tests/test_request_id_concurrency.py
@@ -1,6 +1,8 @@
 """Test that request_id works correctly with concurrent requests."""
 
 import asyncio
+import threading
+
 import pytest
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse
@@ -229,8 +231,6 @@ def test_request_id_with_context_manager_is_thread_safe():
 
         # After context exits, should be cleared in this context
         # (though in threads, contexts are separate anyway)
-
-    import threading
 
     # Create threads that will process with different request_ids
     threads = [


### PR DESCRIPTION
### TL;DR

Moved import statements from inline locations to the top of files across the codebase to follow Python best practices.

### What changed?

Relocated import statements for `hashlib`, `os`, `time`, `pprint`, `logging`, `threading`, and `sqlalchemy` from inline function/method definitions to the top-level imports section of their respective files. This affects:

- `api_server_sql.py`: Moved `hashlib` and `sqlalchemy` imports to top
- `backend_types_sql.py`: Moved `os` and `time` imports to top  
- `kubernetes_launchers.py`: Moved `pprint` import to top
- `orchestrator_sql.py`: Moved `hashlib` and `os` imports to top
- Test files: Moved `logging` and `threading` imports to top

### How to test?

Run the existing test suite to ensure all functionality remains intact. The changes are purely structural and should not affect runtime behavior.

### Why make this change?

Following PEP 8 conventions by placing imports at the top of files improves code readability, makes dependencies more visible, and follows Python community standards. This also eliminates the overhead of repeated imports within functions that may be called multiple times.