### PR TITLE
feat: Set service version on OTel data

### DIFF
--- a/cloud_pipelines_backend/instrumentation/opentelemetry/_internal/configuration.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/_internal/configuration.py
@@ -19,9 +19,13 @@ class OtelConfig:
     endpoint: str
     protocol: str
     service_name: str
+    service_version: str
 
 
-def resolve(service_name: str | None = None) -> OtelConfig | None:
+def resolve(
+    service_name: str | None = None,
+    service_version: str | None = None,
+) -> OtelConfig | None:
     """Read and validate shared OTel configuration from environment variables.
 
     Returns None if OTel is not configured (no exporter endpoint set).
@@ -38,6 +42,9 @@ def resolve(service_name: str | None = None) -> OtelConfig | None:
     if service_name is None:
         app_env = os.environ.get("TANGLE_ENV", "unknown")
         service_name = f"tangle-{app_env}"
+
+    if service_version is None:
+        service_version = os.environ.get("TANGLE_SERVICE_VERSION", "unknown")
 
     if not otel_endpoint.startswith(("http://", "https://")):
         raise ValueError(
@@ -56,4 +63,5 @@ def resolve(service_name: str | None = None) -> OtelConfig | None:
         endpoint=otel_endpoint,
         protocol=otel_protocol,
         service_name=service_name,
+        service_version=service_version,
     )

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/providers.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/providers.py
@@ -6,13 +6,18 @@ Provides entry points to configure OpenTelemetry providers.
 
 import logging
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import configuration
+from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
+    configuration,
+)
 from cloud_pipelines_backend.instrumentation.opentelemetry import tracing
 
 _logger = logging.getLogger(__name__)
 
 
-def setup(service_name: str | None = None) -> None:
+def setup(
+    service_name: str | None = None,
+    service_version: str | None = None,
+) -> None:
     """
     Configure global OpenTelemetry providers (traces, metrics).
 
@@ -23,9 +28,13 @@ def setup(service_name: str | None = None) -> None:
 
     Args:
         service_name: Override the default service name reported to the collector.
+        service_version: Override the default service version (e.g. git revision).
     """
     try:
-        otel_config = configuration.resolve(service_name=service_name)
+        otel_config = configuration.resolve(
+            service_name=service_name,
+            service_version=service_version,
+        )
     except Exception as e:
         _logger.exception("Failed to resolve OpenTelemetry configuration")
         return
@@ -37,6 +46,7 @@ def setup(service_name: str | None = None) -> None:
         endpoint=otel_config.endpoint,
         protocol=otel_config.protocol,
         service_name=otel_config.service_name,
+        service_version=otel_config.service_version,
     )
 
     # TODO: Setup metrics provider once it's available

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/tracing.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/tracing.py
@@ -17,12 +17,19 @@ from opentelemetry.sdk import resources as otel_resources
 from opentelemetry.sdk import trace as otel_trace
 from opentelemetry.sdk.trace import export as otel_trace_export
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import configuration
+from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
+    configuration,
+)
 
 _logger = logging.getLogger(__name__)
 
 
-def setup(endpoint: str, protocol: str, service_name: str) -> None:
+def setup(
+    endpoint: str,
+    protocol: str,
+    service_name: str,
+    service_version: str | None = None,
+) -> None:
     """
     Configure the global OpenTelemetry tracer provider.
 
@@ -30,11 +37,13 @@ def setup(endpoint: str, protocol: str, service_name: str) -> None:
         endpoint: The OTLP collector endpoint URL.
         protocol: The exporter protocol ("grpc" or "http").
         service_name: The service name reported to the collector.
+        service_version: The service version (e.g. git revision) reported to the collector.
     """
     try:
         _logger.info(
             f"Configuring OpenTelemetry tracing, endpoint={endpoint}, "
-            f"protocol={protocol}, service_name={service_name}"
+            f"protocol={protocol}, service_name={service_name}, "
+            f"service_version={service_version}"
         )
 
         if protocol == configuration.ExporterProtocol.GRPC:
@@ -42,9 +51,10 @@ def setup(endpoint: str, protocol: str, service_name: str) -> None:
         else:
             otel_exporter = otel_http_trace_exporter.OTLPSpanExporter(endpoint=endpoint)
 
-        resource = otel_resources.Resource(
-            attributes={otel_resources.SERVICE_NAME: service_name}
-        )
+        attributes = {otel_resources.SERVICE_NAME: service_name}
+        if service_version:
+            attributes[otel_resources.SERVICE_VERSION] = service_version
+        resource = otel_resources.Resource.create(attributes)
         tracer_provider = otel_trace.TracerProvider(resource=resource)
         span_processor = otel_trace_export.BatchSpanProcessor(otel_exporter)
         tracer_provider.add_span_processor(span_processor)

--- a/tests/instrumentation/opentelemetry/_internal/test_configuration.py
+++ b/tests/instrumentation/opentelemetry/_internal/test_configuration.py
@@ -2,7 +2,9 @@
 
 import pytest
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import configuration
+from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
+    configuration,
+)
 
 
 class TestExporterProtocol:
@@ -33,6 +35,7 @@ class TestResolve:
         monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
         monkeypatch.delenv("TANGLE_OTEL_EXPORTER_PROTOCOL", raising=False)
         monkeypatch.delenv("TANGLE_ENV", raising=False)
+        monkeypatch.delenv("TANGLE_SERVICE_VERSION", raising=False)
 
         result = configuration.resolve()
 
@@ -40,6 +43,7 @@ class TestResolve:
         assert result.endpoint == "http://localhost:4317"
         assert result.protocol == configuration.ExporterProtocol.GRPC
         assert result.service_name == "tangle-unknown"
+        assert result.service_version == "unknown"
 
     def test_uses_custom_service_name(self, monkeypatch):
         monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
@@ -94,6 +98,29 @@ class TestResolve:
 
         assert result.endpoint == "https://collector.example.com:4317"
 
+    def test_uses_custom_service_version(self, monkeypatch):
+        monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
+
+        result = configuration.resolve(service_version="abc123")
+
+        assert result.service_version == "abc123"
+
+    def test_service_version_from_env(self, monkeypatch):
+        monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
+        monkeypatch.setenv("TANGLE_SERVICE_VERSION", "def456")
+
+        result = configuration.resolve()
+
+        assert result.service_version == "def456"
+
+    def test_service_version_defaults_to_unknown(self, monkeypatch):
+        monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
+        monkeypatch.delenv("TANGLE_SERVICE_VERSION", raising=False)
+
+        result = configuration.resolve()
+
+        assert result.service_version == "unknown"
+
     def test_config_is_frozen(self, monkeypatch):
         monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
 
@@ -108,4 +135,6 @@ class TestResolve:
         result = configuration.resolve()
 
         with pytest.raises(TypeError):
-            configuration.OtelConfig(result.endpoint, result.protocol, result.service_name)
+            configuration.OtelConfig(
+                result.endpoint, result.protocol, result.service_name
+            )

--- a/tests/instrumentation/opentelemetry/test_providers.py
+++ b/tests/instrumentation/opentelemetry/test_providers.py
@@ -36,6 +36,14 @@ class TestProvidersSetup:
         provider = trace.get_tracer_provider()
         assert provider.resource.attributes["service.name"] == "my-orchestrator"
 
+    def test_passes_custom_service_version(self, monkeypatch):
+        monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "http://localhost:4317")
+
+        providers.setup(service_name="test-service", service_version="abc123")
+
+        provider = trace.get_tracer_provider()
+        assert provider.resource.attributes["service.version"] == "abc123"
+
     def test_catches_validation_errors(self, monkeypatch):
         monkeypatch.setenv("TANGLE_OTEL_EXPORTER_ENDPOINT", "bad-endpoint")
 

--- a/tests/instrumentation/opentelemetry/test_tracing.py
+++ b/tests/instrumentation/opentelemetry/test_tracing.py
@@ -5,7 +5,9 @@ from unittest import mock
 from opentelemetry import trace
 from opentelemetry.sdk import trace as otel_sdk_trace
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import configuration
+from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
+    configuration,
+)
 from cloud_pipelines_backend.instrumentation.opentelemetry import tracing
 
 
@@ -41,6 +43,27 @@ class TestTracingSetup:
 
         provider = trace.get_tracer_provider()
         assert provider.resource.attributes["service.name"] == "my-service"
+
+    def test_service_version_is_set_on_resource(self):
+        tracing.setup(
+            endpoint="http://localhost:4317",
+            protocol="grpc",
+            service_name="my-service",
+            service_version="abc123",
+        )
+
+        provider = trace.get_tracer_provider()
+        assert provider.resource.attributes["service.version"] == "abc123"
+
+    def test_service_version_omitted_when_none(self):
+        tracing.setup(
+            endpoint="http://localhost:4317",
+            protocol="grpc",
+            service_name="my-service",
+        )
+
+        provider = trace.get_tracer_provider()
+        assert "service.version" not in provider.resource.attributes
 
     def test_catches_exporter_exception(self):
         with mock.patch(


### PR DESCRIPTION
### TL;DR

Added service version support to OpenTelemetry configuration and tracing setup.

### What changed?

- Added `service_version` field to `OtelConfig` dataclass
- Extended `resolve()` function to accept optional `service_version` parameter with fallback to `TANGLE_SERVICE_VERSION` environment variable (defaults to "unknown")
- Updated `setup()` functions in both `providers.py` and `tracing.py` to accept and pass through `service_version` parameter
- Modified tracing setup to include `service.version` attribute in OpenTelemetry resource when provided
- Added comprehensive test coverage for service version functionality including custom values, environment variable usage, and default behavior

### How to test?

1. Set `TANGLE_SERVICE_VERSION` environment variable and verify it's picked up by the configuration
2. Pass a custom `service_version` parameter to `providers.setup()` and confirm it overrides the environment variable
3. Check that the `service.version` attribute appears in OpenTelemetry traces when configured (requires OTel collector stack)
4. Verify that when no service version is provided, it defaults to "unknown" and the attribute is omitted from traces when explicitly set to None

### Why make this change?

This enables better observability by allowing services to report their version information (such as git commit hashes or release versions) to OpenTelemetry collectors, making it easier to correlate traces with specific deployments and track issues across different service versions.