### PR TITLE
feat: Measure system errors using a counter

### DIFF
--- a/cloud_pipelines_backend/instrumentation/metrics.py
+++ b/cloud_pipelines_backend/instrumentation/metrics.py
@@ -1,0 +1,36 @@
+"""
+Application-level meters and instruments.
+
+Meters should be named after the software component they represent.
+They should not change over time (avoid using __name__).
+
+Instruments should be named after the metric they represent.
+First and foremost, they should follow the semantic conventions
+(https://opentelemetry.io/docs/specs/semconv/general/metrics/)
+of OTel if the metric is common (e.g. http.server.duration).
+
+For custom, application-specific measurements, choose a name after
+what is being measured, and not after the software component that
+measures it.
+
+Good example:
+- Meter: tangle.orchestrator
+- Instrument: execution.system_errors
+
+Bad example:
+- Meter: tangle.orchestrator
+- Instrument: orchestrator_execution_system_errors
+"""
+
+from opentelemetry import metrics as otel_metrics
+
+# ---------------------------------------------------------------------------
+# tangle.orchestrator
+# ---------------------------------------------------------------------------
+orchestrator_meter = otel_metrics.get_meter("tangle.orchestrator")
+
+execution_system_errors = orchestrator_meter.create_counter(
+    name="execution.system_errors",
+    description="Number of execution nodes that ended in SYSTEM_ERROR status",
+    unit="{error}",
+)

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -21,6 +21,7 @@ from . import component_structures as structures
 from .launchers import common_annotations
 from .launchers import interfaces as launcher_interfaces
 from .instrumentation import contextual_logging
+from .instrumentation import metrics as app_metrics
 
 _logger = logging.getLogger(__name__)
 
@@ -1037,6 +1038,8 @@ def _retry(
 
 
 def record_system_error_exception(execution: bts.ExecutionNode, exception: Exception):
+    app_metrics.execution_system_errors.add(1)
+
     if execution.extra_data is None:
         execution.extra_data = {}
     execution.extra_data[


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry metrics instrumentation to track execution system errors in the orchestrator.

![Screenshot 2026-02-25 at 4.39.17 AM.png](https://app.graphite.com/user-attachments/assets/189b4169-ef35-415a-be02-883bd9ca48a6.png)

![Screenshot 2026-02-25 at 4.41.10 AM.png](https://app.graphite.com/user-attachments/assets/a1c52322-9a54-4b10-97f9-385b590adda5.png)

## **Business** **value**

We will be able to track the rate of system errors and respond to high or increasing rates.

### Future iterations

In the future we will emit metrics for state transitions in general, and use measurement attributes to create dimensions on status, then we will have the option to deprecate to deprecate this measurement specific to system errors.

### What changed?

- Created a new metrics module (`cloud_pipelines_backend/instrumentation/metrics.py`) that defines an orchestrator meter and an `execution_system_errors` counter instrument
- Integrated the metrics counter into the `record_system_error_exception` function in `orchestrator_sql.py` to increment the counter when system errors occur
- Added comprehensive OpenTelemetry strategy documentation (`otel_strategy.md`) covering best practices for meters, instruments, temporality, and aggregation

### How to test?

- Cherry pick the OTel stack from https://app.graphite.com/github/pr/TangleML/tangle/101/feat-Add-development-observability-stack-for-testing-OpenTelemetry-with-Jaeger%2C-and-Prometheus
- Run the stack (`docker-compose up -d`)
- Run `export TANGLE_OTEL_TRACE_EXPORTER_ENDPOINT="http://localhost:4317" && export TANGLE_OTEL_TRACE_EXPORTER_PROTOCOL="grpc" && export TANGLE_OTEL_METRIC_EXPORTER_ENDPOINT="http://localhost:4317" && export TANGLE_OTEL_METRIC_EXPORTER_PROTOCOL="grpc"`
- Trigger execution nodes that result in SYSTEM_ERROR status and verify that the `execution.system_errors` metric is incremented in your OpenTelemetry metrics backend. Add a line `raise RuntimeError("Temporary")` to the start of https://github.com/TangleML/tangle/blob/system-error-metric/cloud_pipelines_backend/orchestrator_sql.py#L209

### Why make this change?

This enables monitoring and alerting on system errors in pipeline executions, providing better observability into the health and reliability of the orchestrator component. The metrics follow OpenTelemetry semantic conventions and provide a foundation for expanding observability coverage across the application.