### PR TITLE
chore: Reduce RuntimeErrors for expected states with no container execution

### DIFF
--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -679,8 +679,14 @@ class ExecutionNodesApiService_Sql:
             raise ItemNotFoundError(f"Execution with {id=} does not exist.")
         container_execution = execution.container_execution
         if not container_execution:
-            raise RuntimeError(
-                f"Execution with {id=} does not have container execution information."
+            status = execution.container_execution_status
+            if not status or status not in bts.CONTAINER_STATUSES_WITH_MISSING_EXECUTION_EXPECTED:
+                raise RuntimeError(
+                    f"Execution with {id=} has status {status} "
+                    f"but is missing its container execution record."
+                )
+            raise errors.ItemNotFoundError(
+                f"Execution with {id=} has status {status.value} and does not have container execution information. This is expected for this status."
             )
         return GetContainerExecutionStateResponse(
             status=container_execution.status,
@@ -756,16 +762,19 @@ class ExecutionNodesApiService_Sql:
             system_error_exception_full or orchestration_error_message
         )
         if not container_execution:
-            if (
-                execution.container_execution_status
-                == bts.ContainerExecutionStatus.SYSTEM_ERROR
-            ):
+            status = execution.container_execution_status
+            if not status or status not in bts.CONTAINER_STATUSES_WITH_MISSING_EXECUTION_EXPECTED:
+                raise RuntimeError(
+                    f"Execution with {id=} has status {status} "
+                    f"but is missing its container execution record."
+                )
+            if status == bts.ContainerExecutionStatus.SYSTEM_ERROR:
                 return GetContainerExecutionLogResponse(
                     system_error_exception_full=system_error_exception_full,
                     orchestration_error_message=orchestration_error_message,
                 )
-            raise RuntimeError(
-                f"Execution with {id=} does not have container execution information."
+            raise errors.ItemNotFoundError(
+                f"Execution with {id=} has status {status.value} and does not have a container execution log. This is expected for this status."
             )
         log_text: str | None = None
         if container_execution.status in (

--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -42,6 +42,20 @@ CONTAINER_STATUSES_ENDED = {
     ContainerExecutionStatus.SKIPPED,
 }
 
+# Statuses where the ContainerExecution record may not exist yet (or ever).
+# These represent expected states before the orchestrator creates and launches
+# a container — e.g. waiting for inputs, sitting in queue, or terminated before
+# launch (cancelled/skipped/system error before container creation).
+CONTAINER_STATUSES_WITH_MISSING_EXECUTION_EXPECTED = {
+    ContainerExecutionStatus.INVALID,
+    ContainerExecutionStatus.UNINITIALIZED,
+    ContainerExecutionStatus.QUEUED,
+    ContainerExecutionStatus.WAITING_FOR_UPSTREAM,
+    ContainerExecutionStatus.SYSTEM_ERROR,
+    ContainerExecutionStatus.CANCELLED,
+    ContainerExecutionStatus.SKIPPED,
+}
+
 
 def generate_unique_id() -> str:
     """Generates a 10-byte (20 hex chars) unique ID.session.add


### PR DESCRIPTION
### TL;DR

Improved error handling for container executions by defining expected statuses where container execution records may be missing and updating error logic accordingly.

### What changed?

Added a new constant `CONTAINER_STATUSES_WITH_MISSING_EXECUTION_EXPECTED` that defines container execution statuses where missing execution records are expected (INVALID, UNINITIALIZED, QUEUED, WAITING_FOR_UPSTREAM, SYSTEM_ERROR, CANCELLED, SKIPPED). Updated `get_container_execution_state()` to throw `ItemNotFoundError` instead of `RuntimeError` when container execution is missing for expected statuses. Modified `get_container_execution_log()` to use the new status validation logic and throw `ItemNotFoundError` for expected missing states while maintaining special handling for SYSTEM_ERROR status.

### How to test?

Test API endpoints for container executions in various states:
- Call `get_container_execution_state()` with executions in QUEUED, CANCELLED, or SKIPPED status and verify it returns `ItemNotFoundError` with appropriate messaging
- Call `get_container_execution_log()` with executions in expected missing states and verify it returns `ItemNotFoundError` for most statuses or error response for SYSTEM_ERROR
- Verify that executions in unexpected states still throw `RuntimeError` when container execution records are missing

### Why make this change?

This change provides more appropriate error handling by distinguishing between expected and unexpected cases where container execution records are missing. For certain statuses like QUEUED or CANCELLED, it's normal for the container execution record to not exist yet or ever, so the API should handle these cases gracefully rather than treating them as unexpected runtime errors.