### PR TITLE
feat: Propagate kubernetes launcher errors to API

### DIFF
--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -501,6 +501,11 @@ class _KubernetesPodLauncher(
                 body=pod,
                 _request_timeout=self._request_timeout,
             )
+        except k8s_client_lib.ApiException as ex:
+            k8s_message = _extract_kubernetes_error_message(ex)
+            raise interfaces.LauncherError(
+                k8s_message or f"Failed to create pod: Kubernetes API error ({ex.status} {ex.reason})"
+            ) from ex
         except Exception as ex:
             raise interfaces.LauncherError(
                 f"Failed to create pod: {_kubernetes_serialize(pod)}"
@@ -1138,6 +1143,11 @@ class _KubernetesJobLauncher(
                 body=job,
                 _request_timeout=self._request_timeout,
             )
+        except k8s_client_lib.ApiException as ex:
+            k8s_message = _extract_kubernetes_error_message(ex)
+            raise interfaces.LauncherError(
+                k8s_message or f"Failed to create Kubernetes Job: Kubernetes API error ({ex.status} {ex.reason})"
+            ) from ex
         except Exception as ex:
             raise interfaces.LauncherError(
                 f"Failed to create Kubernetes Job: {_kubernetes_serialize(job)}"
@@ -1680,6 +1690,20 @@ def windows_path_to_docker_path(path: str) -> str:
 def _kubernetes_serialize(obj) -> dict[str, Any]:
     shallow_client = k8s_client_lib.ApiClient.__new__(k8s_client_lib.ApiClient)
     return shallow_client.sanitize_for_serialization(obj)
+
+
+def _extract_kubernetes_error_message(ex: k8s_client_lib.ApiException) -> str | None:
+    """Extract the human-readable message from a Kubernetes ApiException body.
+
+    The Kubernetes API returns structured JSON error bodies with a top-level
+    'message' field that contains the admission webhook rejection reason —
+    far more actionable than a raw pod/job spec dump.
+    """
+    try:
+        body = json.loads(ex.body)
+        return body.get("message") or None
+    except Exception:
+        return None
 
 
 def _kubernetes_deserialize(obj_dict: dict[str, Any], cls: typing.Type[_T]) -> _T:

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -586,6 +586,11 @@ class OrchestratorService_Sql:
                     bts.ContainerExecutionStatus.SYSTEM_ERROR
                 )
                 record_system_error_exception(execution=execution, exception=ex)
+                if execution.extra_data is None:
+                    execution.extra_data = {}
+                execution.extra_data[
+                    bts.EXECUTION_NODE_EXTRA_DATA_ORCHESTRATION_ERROR_MESSAGE_KEY
+                ] = str(ex)
                 _mark_all_downstream_executions_as_skipped(
                     session=session, execution=execution
                 )


### PR DESCRIPTION
### TL;DR

Enhanced Kubernetes error handling to extract and display meaningful error messages from API exceptions instead of dumping raw pod/job specifications.

### What changed?

Added specific handling for `k8s_client_lib.ApiException` in both pod and job creation methods within the Kubernetes launchers. The new error handling extracts human-readable messages from the Kubernetes API response body and stores orchestration error messages in execution extra data for better debugging visibility.

### How to test?

1. Trigger a Kubernetes pod or job creation that would fail due to admission webhook rejection or other API validation errors
2. Verify that the error message displays the actual Kubernetes API error reason instead of a serialized pod/job specification
3. Check that the orchestration error message is stored in the execution's extra data for system errors

### Why make this change?

Kubernetes API returns structured JSON error responses with actionable error messages (like admission webhook rejection reasons), but the previous implementation would dump the entire pod/job specification instead. This change provides much more useful debugging information by surfacing the actual root cause of failures.