### PR TITLE
chore: Code owners - Added Morgan Wowk as code owner for the instrumentation and observability directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @Ark-kun
+
+/cloud_pipelines_backend/instrumentation/  @morgan-wowk
+/examples/observability/  @morgan-wowk
+/tests/instrumentation/  @morgan-wowk


### PR DESCRIPTION
Morgan has OpenTelemetry expertize and has created the instrumentation modules.
So he should be the main owner and reviewer for these modules.