### PR TITLE
fix: No StrEnum for python 3.10

### DIFF
--- a/cloud_pipelines_backend/filter_query_sql.py
+++ b/cloud_pipelines_backend/filter_query_sql.py
@@ -14,7 +14,15 @@ SYSTEM_KEY_PREFIX: Final[str] = "system/"
 _PIPELINE_RUN_KEY_PREFIX: Final[str] = f"{SYSTEM_KEY_PREFIX}pipeline_run."
 
 
-class PipelineRunAnnotationSystemKey(enum.StrEnum):
+class PipelineRunAnnotationSystemKey(str, enum.Enum):
+    # Python <3.11 compat (no enum.StrEnum). Without these overrides:
+    #   __str__:  str(MEMBER) returns 'ClassName.MEMBER' instead of the value,
+    #             breaking sqlalchemy.literal(str(key)) in backfill queries.
+    #   __hash__: hash(MEMBER) != hash("value"), breaking dict lookups like
+    #             annotations[MEMBER] when the dict has plain string keys.
+    __hash__ = str.__hash__
+    __str__ = str.__str__
+
     CREATED_BY = f"{_PIPELINE_RUN_KEY_PREFIX}created_by"
     PIPELINE_NAME = f"{_PIPELINE_RUN_KEY_PREFIX}name"
     CREATED_AT = f"{_PIPELINE_RUN_KEY_PREFIX}date.created_at"


### PR DESCRIPTION
### TL;DR

Added Python <3.11 compatibility for `PipelineRunAnnotationSystemKey` enum by replacing `enum.StrEnum` with `str, enum.Enum` and custom method overrides.

### What changed?

The `PipelineRunAnnotationSystemKey` class now inherits from `str, enum.Enum` instead of `enum.StrEnum` and includes custom `__hash__` and `__str__` method overrides to maintain proper string behavior for SQLAlchemy queries and dictionary lookups.

### How to test?

```
uv run pytest tests/test_filter_query_models.py tests/test_api_server_sql.py tests/test_filter_query_sql.py tests/test_database_ops.py
```

![image.png](https://app.graphite.com/user-attachments/assets/71d7e3ce-ed3f-442c-8cb7-7fc98b5eb962.png)

### Why make this change?

Failing tests in CI/CD and pyproject.toml states minimum python version support is 3.10