### PR TITLE
chore: Update OTel package to use relative imports

### DIFF
--- a/cloud_pipelines_backend/instrumentation/opentelemetry/__init__.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/__init__.py
@@ -9,10 +9,10 @@ Usage::
     otel.instrument_fastapi(app)
 """
 
-from cloud_pipelines_backend.instrumentation.opentelemetry import auto_instrumentation
-from cloud_pipelines_backend.instrumentation.opentelemetry import metrics
-from cloud_pipelines_backend.instrumentation.opentelemetry import providers
-from cloud_pipelines_backend.instrumentation.opentelemetry import tracing
+from . import auto_instrumentation
+from . import metrics
+from . import providers
+from . import tracing
 
 instrument_fastapi = auto_instrumentation.instrument_fastapi
 setup_metrics = metrics.setup


### PR DESCRIPTION
### TL;DR

Contributes to https://github.com/Shopify/oasis-frontend/issues/445

Converted absolute imports to relative imports in the OpenTelemetry instrumentation module.

### What changed?

Changed the import statements in `cloud_pipelines_backend/instrumentation/opentelemetry/__init__.py` from absolute imports using the full module path to relative imports using dot notation. The imports for `auto_instrumentation`, `metrics`, `providers`, and `tracing` modules now use `from . import` instead of `from cloud_pipelines_backend.instrumentation.opentelemetry import`.

### How to test?

Verify that the OpenTelemetry instrumentation functionality still works correctly by:

- Running the application and ensuring FastAPI instrumentation initializes properly
- Confirming that metrics, tracing, and auto-instrumentation features function as expected
- Running any existing tests that cover the OpenTelemetry instrumentation module

Local verification has been performed ✅

### Why make this change?

Relative imports make the code more maintainable and portable by reducing dependency on the absolute module path. This change also follows Python best practices for intra-package imports and makes the code cleaner and more readable. Furthermore, it allows projects treating Tangle as a submodule to safely import **without any sys path manipulations**.