### PR TITLE
fix: PipelineRun Search - Fixed backfill for MySQL when annotation value length > 255

### DIFF
--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -1226,6 +1226,29 @@ _ArtifactNodeOrDynamicDataType = typing.Union[
 ]
 
 
+def _truncate_for_annotation(
+    *,
+    value: str,
+    field_name: str,
+    pipeline_run_id: bts.IdType,
+) -> str:
+    """Truncate a string to fit the annotation VARCHAR column.
+
+    Returns the value unchanged if it fits within _STR_MAX_LENGTH,
+    otherwise truncates and logs a warning with the run ID and
+    original length.
+    """
+    max_len = bts._STR_MAX_LENGTH
+    if len(value) <= max_len:
+        return value
+
+    _logger.warning(
+        f"Truncating {field_name} annotation for run {pipeline_run_id}: "
+        f"{len(value)} chars -> {max_len} chars"
+    )
+    return value[:max_len]
+
+
 def _mirror_system_annotations(
     *,
     session: orm.Session,
@@ -1233,8 +1256,20 @@ def _mirror_system_annotations(
     created_by: str | None,
     pipeline_name: str | None,
 ) -> None:
-    """Mirror pipeline run fields as system annotations for filter_query search."""
+    """Mirror pipeline run fields as system annotations for filter_query search"""
+
+    # TODO: The original pipeline_run.created_by and the pipeline name stored in
+    # extra_data / task_spec are saved untruncated, while the annotation mirror
+    # is truncated to VARCHAR(255). This creates a data parity mismatch between
+    # the source columns and their annotation copies. Revisit this to either
+    # widen the annotation column or enforce the same limit at the source.
+
     if created_by:
+        created_by = _truncate_for_annotation(
+            value=created_by,
+            field_name=filter_query_sql.PipelineRunAnnotationSystemKey.CREATED_BY,
+            pipeline_run_id=pipeline_run_id,
+        )
         session.add(
             bts.PipelineRunAnnotation(
                 pipeline_run_id=pipeline_run_id,
@@ -1243,6 +1278,11 @@ def _mirror_system_annotations(
             )
         )
     if pipeline_name:
+        pipeline_name = _truncate_for_annotation(
+            value=pipeline_name,
+            field_name=filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME,
+            pipeline_run_id=pipeline_run_id,
+        )
         session.add(
             bts.PipelineRunAnnotation(
                 pipeline_run_id=pipeline_run_id,

--- a/cloud_pipelines_backend/backend_types_sql.py
+++ b/cloud_pipelines_backend/backend_types_sql.py
@@ -96,6 +96,9 @@ class UtcDateTime(sql.TypeDecorator):
         return value
 
 
+_STR_MAX_LENGTH: Final[int] = 255
+
+
 class _TableBase(orm.MappedAsDataclass, orm.DeclarativeBase, kw_only=True):
     # Not really needed due to kw_only=True
     _: dataclasses.KW_ONLY
@@ -117,7 +120,7 @@ class _TableBase(orm.MappedAsDataclass, orm.DeclarativeBase, kw_only=True):
         # structures.TypeSpecType: sql.JSON,  # !!! Gotcha. This causes str map to JSON
         # SqlIOTypeStruct: sql.JSON,
         # PipelineSpec: sql.JSON,
-        str: sql.String(255),
+        str: sql.String(_STR_MAX_LENGTH),
         datetime.datetime: UtcDateTime,  # sql.DateTime(timezone=True) is not enough
     }
 

--- a/cloud_pipelines_backend/database_ops.py
+++ b/cloud_pipelines_backend/database_ops.py
@@ -173,6 +173,11 @@ def _backfill_pipeline_names_from_extra_data(
     when extra_data is NULL or the key is absent (no Python error).
     """
     pipeline_name_expr = bts.PipelineRun.extra_data["pipeline_name"].as_string()
+    truncated_name = sqlalchemy.func.substr(
+        pipeline_name_expr,
+        1,
+        bts._STR_MAX_LENGTH,
+    )
     stmt = sqlalchemy.insert(bts.PipelineRunAnnotation).from_select(
         ["pipeline_run_id", "key", "value"],
         sqlalchemy.select(
@@ -180,7 +185,7 @@ def _backfill_pipeline_names_from_extra_data(
             sqlalchemy.literal(
                 filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME,
             ),
-            pipeline_name_expr,
+            truncated_name,
         ).where(
             pipeline_name_expr.isnot(None),
         ),
@@ -305,6 +310,11 @@ def _backfill_pipeline_names_from_component_spec(
     name_expr = bts.ExecutionNode.task_spec[
         ("componentRef", "spec", "name")
     ].as_string()
+    truncated_name = sqlalchemy.func.substr(
+        name_expr,
+        1,
+        bts._STR_MAX_LENGTH,
+    )
     existing_ann = orm.aliased(bts.PipelineRunAnnotation)
 
     # Step 4: INSERT INTO pipeline_run_annotation
@@ -313,7 +323,7 @@ def _backfill_pipeline_names_from_component_spec(
         sqlalchemy.select(
             bts.PipelineRun.id,
             sqlalchemy.literal(str(key)),
-            name_expr,
+            truncated_name,
         )
         # Step 1: INNER JOIN execution_node
         .join(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Shared pytest fixtures for all tests in this directory.
+
+pytest automatically discovers files named ``conftest.py`` and makes any
+fixtures defined here available to every test module in the same directory
+(and subdirectories) -- no import required.  Tests request fixtures simply
+by naming them as function parameters.
+"""
+
+import pytest
+from sqlalchemy import orm
+from sqlalchemy import sql
+
+from cloud_pipelines_backend import backend_types_sql as bts
+from cloud_pipelines_backend import database_ops
+
+
+@pytest.fixture()
+def mysql_varchar_limit_session_factory() -> orm.sessionmaker:
+    """SQLite engine with TRIGGER-based VARCHAR length enforcement.
+
+    Mimics MySQL's DataError 1406 by rejecting INSERT/UPDATE on
+    pipeline_run_annotation when key or value exceeds the VARCHAR
+    limit from type_annotation_map.
+    """
+    max_len = bts._TableBase.type_annotation_map[str].length
+    db_engine = database_ops.create_db_engine(database_uri="sqlite://")
+    bts._TableBase.metadata.create_all(db_engine)
+    with db_engine.connect() as conn:
+        conn.execute(sql.text(f"""
+            CREATE TRIGGER enforce_annotation_value_length
+            BEFORE INSERT ON pipeline_run_annotation
+            FOR EACH ROW
+            WHEN length(NEW.value) > {max_len}
+            BEGIN
+                SELECT RAISE(ABORT, 'Data too long for column value');
+            END
+        """))
+        conn.execute(sql.text(f"""
+            CREATE TRIGGER enforce_annotation_key_length
+            BEFORE INSERT ON pipeline_run_annotation
+            FOR EACH ROW
+            WHEN length(NEW.key) > {max_len}
+            BEGIN
+                SELECT RAISE(ABORT, 'Data too long for column key');
+            END
+        """))
+        conn.commit()
+    return orm.sessionmaker(db_engine)

--- a/tests/test_api_server_sql.py
+++ b/tests/test_api_server_sql.py
@@ -582,6 +582,135 @@ class TestPipelineRunAnnotationCrud:
                 )
 
 
+class TestTruncateForAnnotation:
+    """Unit tests for _truncate_for_annotation() helper."""
+
+    def test_exact_255_unchanged(self) -> None:
+        value = "a" * bts._STR_MAX_LENGTH
+        result = api_server_sql._truncate_for_annotation(
+            value=value,
+            field_name=filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME,
+            pipeline_run_id="run-1",
+        )
+        assert result == value
+
+    def test_256_truncated_and_logs_warning(self, caplog) -> None:
+        value = "b" * 256
+        field = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        with caplog.at_level("WARNING"):
+            result = api_server_sql._truncate_for_annotation(
+                value=value,
+                field_name=field,
+                pipeline_run_id="run-xyz",
+            )
+        assert result == "b" * bts._STR_MAX_LENGTH
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "run-xyz" in msg
+        assert str(field) in msg
+
+
+class TestAnnotationValueOverflow:
+    """Reproduction tests using mysql_varchar_limit_session_factory (SQLite TRIGGER
+    enforcement). These tests prove that >255 char values are rejected,
+    mimicking MySQL's DataError 1406.
+
+    Covers all write paths into pipeline_run_annotation:
+    - set_annotation(): long key, long value
+    - create() via _mirror_system_annotations(): long pipeline_name, long created_by
+    """
+
+    # TODO: set_annotation() currently has no truncation guard for the
+    # VARCHAR(255) limit on annotation key/value columns. These tests
+    # document the failure. Fix deferred to a separate PR to avoid
+    # convoluting the backfill + _mirror_system_annotations fix.
+
+    def test_set_annotation_long_value_raises_on_overflow(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+        service: api_server_sql.PipelineRunsApiService_Sql,
+    ) -> None:
+        """set_annotation() with a 300-char value overflows the
+        VARCHAR(255) column and triggers IntegrityError."""
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="user1",
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            with pytest.raises(
+                sqlalchemy.exc.IntegrityError, match="Data too long.*value"
+            ):
+                service.set_annotation(
+                    session=session,
+                    id=run.id,
+                    key="team",
+                    value="v" * 300,
+                    user_name="user1",
+                )
+
+    def test_set_annotation_long_key_raises_on_overflow(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+        service: api_server_sql.PipelineRunsApiService_Sql,
+    ) -> None:
+        """set_annotation() with a 300-char key overflows the
+        VARCHAR(255) key column and triggers IntegrityError."""
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="user1",
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            with pytest.raises(
+                sqlalchemy.exc.IntegrityError, match="Data too long.*key"
+            ):
+                service.set_annotation(
+                    session=session,
+                    id=run.id,
+                    key="k" * 300,
+                    value="short",
+                    user_name="user1",
+                )
+
+    def test_create_run_long_pipeline_name_truncated(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+        service: api_server_sql.PipelineRunsApiService_Sql,
+    ) -> None:
+        """create() with a 300-char pipeline name is truncated to 255
+        in _mirror_system_annotations()."""
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec("p" * 300),
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == "p" * bts._STR_MAX_LENGTH
+
+    def test_create_run_long_created_by_truncated(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+        service: api_server_sql.PipelineRunsApiService_Sql,
+    ) -> None:
+        """create() with a 300-char created_by is truncated to 255
+        in _mirror_system_annotations()."""
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="u" * 300,
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.CREATED_BY
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == "u" * bts._STR_MAX_LENGTH
+
+
 class TestFilterQueryApiWiring:
     def test_filter_query_validates_invalid_json(self, session_factory, service):
         from pydantic import ValidationError

--- a/tests/test_database_ops.py
+++ b/tests/test_database_ops.py
@@ -511,6 +511,157 @@ class TestPipelineNameBackfill:
             annotations = service.list_annotations(session=session, id=run.id)
         assert annotations[key] == ""
 
+    # --- Overflow truncation tests ---
+    # Uses mysql_varchar_limit_session_factory with SQLite TRIGGER enforcement.
+    # Verifies that backfill truncates >255 char values to 255,
+    # preventing MySQL DataError 1406.
+
+    def test_backfill_p1_long_name_truncated(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+    ) -> None:
+        """P1: a 300-char pipeline_name in extra_data is truncated to 255."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(pipeline_name="some-name"),
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        _delete_annotation(
+            session_factory=mysql_varchar_limit_session_factory, run_id=run.id, key=key
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            assert key not in service.list_annotations(session=session, id=run.id)
+
+        long_name = "x" * 300
+        with mysql_varchar_limit_session_factory() as session:
+            db_run = session.get(bts.PipelineRun, run.id)
+            db_run.extra_data = {"pipeline_name": long_name}
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            database_ops._backfill_pipeline_names_from_extra_data(session=session)
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == "x" * bts._STR_MAX_LENGTH
+
+    def test_backfill_p1_exact_255_preserved(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+    ) -> None:
+        """P1: a 255-char pipeline_name is stored without truncation."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(pipeline_name="some-name"),
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        _delete_annotation(
+            session_factory=mysql_varchar_limit_session_factory, run_id=run.id, key=key
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            assert key not in service.list_annotations(session=session, id=run.id)
+
+        exact_name = "x" * bts._STR_MAX_LENGTH
+        with mysql_varchar_limit_session_factory() as session:
+            db_run = session.get(bts.PipelineRun, run.id)
+            db_run.extra_data = {"pipeline_name": exact_name}
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            database_ops._backfill_pipeline_names_from_extra_data(session=session)
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == exact_name
+
+    def test_backfill_p2_long_name_truncated(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+    ) -> None:
+        """P2: a 300-char name in task_spec is truncated to 255."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(pipeline_name="some-name"),
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        _delete_annotation(
+            session_factory=mysql_varchar_limit_session_factory, run_id=run.id, key=key
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            assert key not in service.list_annotations(session=session, id=run.id)
+
+        long_name = "y" * 300
+        with mysql_varchar_limit_session_factory() as session:
+            db_run = session.get(bts.PipelineRun, run.id)
+            db_run.extra_data = None
+            session.commit()
+        _set_execution_node_task_spec_raw(
+            session_factory=mysql_varchar_limit_session_factory,
+            run_id=run.id,
+            task_spec_dict={
+                "componentRef": {"spec": {"name": long_name}},
+            },
+        )
+
+        with mysql_varchar_limit_session_factory() as session:
+            database_ops._backfill_pipeline_names_from_component_spec(
+                session=session,
+            )
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == "y" * bts._STR_MAX_LENGTH
+
+    def test_backfill_p2_exact_255_preserved(
+        self,
+        mysql_varchar_limit_session_factory: orm.sessionmaker,
+    ) -> None:
+        """P2: a 255-char name in task_spec is stored without truncation."""
+        service = api_server_sql.PipelineRunsApiService_Sql()
+        run = _create_run(
+            mysql_varchar_limit_session_factory,
+            service,
+            root_task=_make_task_spec(pipeline_name="some-name"),
+        )
+        key = filter_query_sql.PipelineRunAnnotationSystemKey.PIPELINE_NAME
+        _delete_annotation(
+            session_factory=mysql_varchar_limit_session_factory, run_id=run.id, key=key
+        )
+        with mysql_varchar_limit_session_factory() as session:
+            assert key not in service.list_annotations(session=session, id=run.id)
+
+        exact_name = "y" * bts._STR_MAX_LENGTH
+        with mysql_varchar_limit_session_factory() as session:
+            db_run = session.get(bts.PipelineRun, run.id)
+            db_run.extra_data = None
+            session.commit()
+        _set_execution_node_task_spec_raw(
+            session_factory=mysql_varchar_limit_session_factory,
+            run_id=run.id,
+            task_spec_dict={
+                "componentRef": {"spec": {"name": exact_name}},
+            },
+        )
+
+        with mysql_varchar_limit_session_factory() as session:
+            database_ops._backfill_pipeline_names_from_component_spec(
+                session=session,
+            )
+            session.commit()
+
+        with mysql_varchar_limit_session_factory() as session:
+            annotations = service.list_annotations(session=session, id=run.id)
+        assert annotations[key] == exact_name
+
     # --- Phase 2 tests (_backfill_pipeline_names_from_component_spec) ---
     # Ordered by JSON traversal depth (0 -> 4).
     # Path: ExecutionNode row -> task_spec -> componentRef -> spec -> name


### PR DESCRIPTION
### TL;DR

Added string truncation to prevent database errors when `pipeline names` or `created by` exceed the 255-character VARCHAR limit in annotation `value` column.  This fix is applied during:

- Backfilling pipeline name to annotations table.
- Pipeline create/start and the `created by` or `pipeline name` > 255 characters:
  - Truncation will happen ONLY for annotations table, run will be allowed to start with a warning log.

### What changed?

- Added `_truncate_for_annotation()` helper function that truncates strings to 255 characters and logs warnings when truncation occurs
- Applied truncation to `created_by` and `pipeline_name` values in `_mirror_system_annotations()` before inserting into the database
- Updated database backfill operations to truncate pipeline names using `sqlalchemy.func.substr()` 
- Extracted the VARCHAR length limit (255) into a shared constant `_STR_MAX_LENGTH`
- Added comprehensive test coverage including a custom SQLite fixture that mimics MySQL's VARCHAR overflow behavior

### How to test?

```
uv run pytest tests/test_api_server_sql.py tests/test_database_ops.py
```

Run the new test classes:
- `TestTruncateForAnnotation` - Unit tests for the truncation helper function
- `TestAnnotationValueOverflow` - Integration tests that verify truncation prevents database errors
- Extended `TestBackfillPipelineNames` - Tests that backfill operations properly truncate long values

The tests use a special SQLite fixture with triggers that simulate MySQL's strict VARCHAR enforcement.

### Why make this change?

This is blocking production from being released because the backfill needs to happen first before release is successful.