### PR TITLE
chore: Switch to relative imports within the opentelemetry modules

### DIFF
--- a/cloud_pipelines_backend/instrumentation/opentelemetry/_internal/temporality.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/_internal/temporality.py
@@ -6,9 +6,7 @@ from opentelemetry import metrics as otel_metrics
 from opentelemetry.sdk import metrics as otel_sdk_metrics
 from opentelemetry.sdk.metrics import export as otel_metrics_export
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
-    configuration,
-)
+from . import configuration
 
 _TEMPORALITY_MAP = {
     configuration.AggregationTemporality.DELTA: otel_metrics_export.AggregationTemporality.DELTA,

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/auto_instrumentation.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/auto_instrumentation.py
@@ -10,7 +10,7 @@ import logging
 
 from opentelemetry.instrumentation import fastapi as otel_fastapi
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import providers
+from ._internal import providers
 
 _logger = logging.getLogger(__name__)
 

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/metrics.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/metrics.py
@@ -17,12 +17,8 @@ from opentelemetry.sdk import metrics as otel_sdk_metrics
 from opentelemetry.sdk import resources as otel_resources
 from opentelemetry.sdk.metrics import export as otel_metrics_export
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
-    configuration,
-)
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
-    temporality as temporality_mod,
-)
+from ._internal import configuration
+from ._internal import temporality as temporality_mod
 
 _logger = logging.getLogger(__name__)
 

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/providers.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/providers.py
@@ -6,11 +6,9 @@ Provides entry points to configure OpenTelemetry providers.
 
 import logging
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
-    configuration,
-)
-from cloud_pipelines_backend.instrumentation.opentelemetry import metrics
-from cloud_pipelines_backend.instrumentation.opentelemetry import tracing
+from ._internal import configuration
+from . import metrics
+from . import tracing
 
 _logger = logging.getLogger(__name__)
 

--- a/cloud_pipelines_backend/instrumentation/opentelemetry/tracing.py
+++ b/cloud_pipelines_backend/instrumentation/opentelemetry/tracing.py
@@ -17,9 +17,7 @@ from opentelemetry.sdk import resources as otel_resources
 from opentelemetry.sdk import trace as otel_trace
 from opentelemetry.sdk.trace import export as otel_trace_export
 
-from cloud_pipelines_backend.instrumentation.opentelemetry._internal import (
-    configuration,
-)
+from ._internal import configuration
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### TL;DR

Refactored import statements in OpenTelemetry instrumentation modules to use relative imports instead of absolute imports.

### How to test?

Run the existing test suite to ensure all imports resolve correctly and no functionality is broken. Verify that the OpenTelemetry instrumentation features continue to work as expected.

**Local verification has been completed** ✅

### Why make this change?

Relative imports improve code maintainability by reducing coupling to the full package path structure. This makes the code more portable and easier to refactor if the package structure changes in the future. Furthermore, it allows projects using Tangle as a submodule to import opentelemetry modules **without any sys path manipulations**.