### PR TITLE
chore: Add .envrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/


### PR DESCRIPTION
### TL;DR

Added `.envrc` to `.gitignore` to exclude direnv configuration files from version control

### What changed?

Added `.envrc` to the `.gitignore` file in the Environments section alongside other environment-related files like `.env` and `.venv`.

### How to test?

1. Create a `.envrc` file in the project root
2. Run `git status` to verify the file is not tracked
3. Confirm that existing environment files like `.env` are still properly ignored

### Why make this change?

The `.envrc` file is used by direnv to automatically load environment variables when entering a directory. This file often contains sensitive configuration data or local development settings that should not be committed to version control.