### PR TITLE
Add optional total_count field to ListPipelineJobsResponse

### DIFF
--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -84,6 +84,7 @@ class GetPipelineRunResponse(PipelineRunResponse):
 class ListPipelineJobsResponse:
     pipeline_runs: list[PipelineRunResponse]
     next_page_token: str | None = None
+    total_count: int | None = None
 
 
 class PipelineRunsApiService_Sql:
@@ -206,6 +207,7 @@ class PipelineRunsApiService_Sql:
         current_user: str | None = None,
         include_pipeline_names: bool = False,
         include_execution_stats: bool = False,
+        include_total_count: bool = False,
     ) -> ListPipelineJobsResponse:
         where_clauses, offset, next_token = filter_query_sql.build_list_filters(
             filter_value=filter,
@@ -225,6 +227,14 @@ class PipelineRunsApiService_Sql:
             ).all()
         )
 
+        total_count = None
+        if include_total_count:
+            total_count = session.scalar(
+                sql.select(sql.func.count())
+                .select_from(bts.PipelineRun)
+                .where(*where_clauses)
+            )
+
         next_page_token = (
             next_token if len(pipeline_runs) >= self._DEFAULT_PAGE_SIZE else None
         )
@@ -240,6 +250,7 @@ class PipelineRunsApiService_Sql:
                 for pipeline_run in pipeline_runs
             ],
             next_page_token=next_page_token,
+            total_count=total_count,
         )
 
     def _create_pipeline_run_response(

--- a/tests/test_api_server_sql.py
+++ b/tests/test_api_server_sql.py
@@ -230,6 +230,84 @@ class TestPipelineRunServiceList:
         assert len(result.pipeline_runs) == 1
         assert result.pipeline_runs[0].created_by == "alice@example.com"
 
+    def test_list_total_count_not_included_by_default(self, session_factory, service):
+        _create_run(session_factory, service, root_task=_make_task_spec())
+
+        with session_factory() as session:
+            result = service.list(session=session)
+        assert len(result.pipeline_runs) == 1
+        assert result.total_count is None
+
+    def test_list_total_count_empty(self, session_factory, service):
+        with session_factory() as session:
+            result = service.list(session=session, include_total_count=True)
+        assert result.total_count == 0
+
+    def test_list_total_count_matches_results(self, session_factory, service):
+        _create_run(session_factory, service, root_task=_make_task_spec("a"))
+        _create_run(session_factory, service, root_task=_make_task_spec("b"))
+        _create_run(session_factory, service, root_task=_make_task_spec("c"))
+
+        with session_factory() as session:
+            result = service.list(session=session, include_total_count=True)
+        assert len(result.pipeline_runs) == 3
+        assert result.total_count == 3
+
+    def test_list_total_count_with_pagination(self, session_factory, service):
+        for i in range(12):
+            _create_run(
+                session_factory,
+                service,
+                root_task=_make_task_spec(f"pipeline-{i}"),
+            )
+
+        with session_factory() as session:
+            page1 = service.list(session=session, include_total_count=True)
+        assert len(page1.pipeline_runs) == 10
+        assert page1.total_count == 12
+
+        with session_factory() as session:
+            page2 = service.list(
+                session=session,
+                page_token=page1.next_page_token,
+                include_total_count=True,
+            )
+        assert len(page2.pipeline_runs) == 2
+        assert page2.total_count == 12
+
+    def test_list_total_count_with_filter(self, session_factory, service):
+        _create_run(
+            session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="user1",
+        )
+        _create_run(
+            session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="user1",
+        )
+        _create_run(
+            session_factory,
+            service,
+            root_task=_make_task_spec(),
+            created_by="user2",
+        )
+
+        with session_factory() as session:
+            result = service.list(
+                session=session,
+                filter="created_by:user1",
+                include_total_count=True,
+            )
+        assert len(result.pipeline_runs) == 2
+        assert result.total_count == 2
+
+        with session_factory() as session:
+            all_result = service.list(session=session, include_total_count=True)
+        assert all_result.total_count == 3
+
 
 class TestCreatePipelineRunResponse:
     def test_base_response(self, session_factory, service):


### PR DESCRIPTION
### TL;DR

Added `total_count` field to the `ListPipelineJobsResponse` to provide the total number of pipeline runs matching the query criteria when requested.

### What changed?

- Added `total_count: int | None = None` field to `ListPipelineJobsResponse` class
- Added `include_total_count: bool = False` parameter to the `list` method in `PipelineRunsApiService_Sql`
- When `include_total_count` is True, the method executes a count query using `sql.func.count()` with the same filter conditions as the main query
- The `total_count` is populated in the response object when the parameter is enabled

### How to test?

Run the existing test suite which now includes comprehensive tests for the `total_count` functionality:
- `test_list_total_count_not_included_by_default` - verifies count is None by default
- `test_list_total_count_empty` - verifies count is 0 when no runs exist
- `test_list_total_count_matches_results` - confirms count matches actual results
- `test_list_total_count_with_pagination` - ensures count remains consistent across paginated requests
- `test_list_total_count_with_filter` - validates count respects filter conditions

### Why make this change?

This enhancement allows clients to optionally retrieve the total number of pipeline runs that match their query criteria, which is essential for implementing proper pagination controls and displaying accurate result counts in user interfaces. The feature is opt-in to avoid performance overhead when the total count is not needed.