### PR TITLE
chore: Switch delete user settings endpoint to read from query params

### DIFF
--- a/cloud_pipelines_backend/api_router.py
+++ b/cloud_pipelines_backend/api_router.py
@@ -548,10 +548,14 @@ def _setup_routes_internal(
         )
     )
     router.delete("/api/users/me/settings", tags=["user_settings"], **default_config)(
-        inject_session_dependency(
-            inject_user_name(
-                user_settings_service.delete_settings, parameter_name="user_id"
-            )
+        add_parameter_annotation_metadata(
+            inject_session_dependency(
+                inject_user_name(
+                    user_settings_service.delete_settings, parameter_name="user_id"
+                )
+            ),
+            parameter_name="setting_names",
+            annotation_metadata=fastapi.Query(),
         )
     )
     # endregion


### PR DESCRIPTION
**Changes:**

* Wrap delete user settings handler in `add_parameter_annotation_metadata` to instruct FastAPI to read `setting_names` parameter from query params