### PR TITLE
fix: Fix orchestrator query for (PENDING, RUNNING) by ID only

### DIFF
--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -131,8 +131,9 @@ class OrchestratorService_Sql:
             return False
 
     def internal_process_running_executions_queue(self, session: orm.Session):
-        query = (
-            sql.select(bts.ContainerExecution)
+        # Select only the ID to avoid loading large JSON columns into the sort buffer.
+        id_query = (
+            sql.select(bts.ContainerExecution.id)
             .where(
                 bts.ContainerExecution.status.in_(
                     (
@@ -144,7 +145,10 @@ class OrchestratorService_Sql:
             .order_by(bts.ContainerExecution.last_processed_at)
             .limit(1)
         )
-        running_container_execution = session.scalar(query)
+        execution_id = session.scalar(id_query)
+        running_container_execution = (
+            session.get(bts.ContainerExecution, execution_id) if execution_id else None
+        )
         if running_container_execution:
             self._running_executions_queue_idle = False
             start_timestamp = time.monotonic_ns()


### PR DESCRIPTION
### TL;DR

Optimized the running executions queue query to avoid loading large JSON columns into MySQL's sort buffer.

### What changed?

The query in `internal_process_running_executions_queue` was split into two steps. Instead of selecting the full `ContainerExecution` row (including potentially large JSON columns) with an `ORDER BY` and `LIMIT`, it now first selects only the `id` column to find the target execution, then fetches the full row by primary key using `session.get()`.

### How to test?

Run the orchestrator against a database with `ContainerExecution` rows that have large JSON column values and verify that running executions are still processed correctly without errors or performance regressions.

### Why make this change?

When MySQL performs a `ORDER BY ... LIMIT` query, it loads all selected columns into the sort buffer. Selecting the entire `ContainerExecution` row — including large JSON columns — was causing the sort buffer to be unnecessarily large. By selecting only the `id` first, the sort operation is performed on a minimal dataset, reducing memory pressure and improving query performance.

### Evidence

#### Sorting by ID only (WORKS)

```
SELECT id
FROM container_execution
WHERE status IN ('PENDING', 'RUNNING')
ORDER BY last_processed_at
LIMIT 1;
```

![image.png](https://app.graphite.com/user-attachments/assets/7ba396b6-1547-41fa-af67-d2b0aae3b1d7.png)

#### Sorting all (FAILS)

```
SELECT *
FROM container_execution
WHERE status IN ('PENDING', 'RUNNING')
ORDER BY last_processed_at
LIMIT 1;
```

![image.png](https://app.graphite.com/user-attachments/assets/58a404d1-d25e-41e9-bed8-2d5ea8aa895b.png)

#### Resorts to filesort

![image.png](https://app.graphite.com/user-attachments/assets/bac6ac43-9486-4b85-9279-a9c55640a25f.png)

#### Alot of runs in those statuses

![image.png](https://app.graphite.com/user-attachments/assets/37d113dd-3dcb-4bf2-ae55-83a9c18fb76b.png)

