### PR TITLE
chore: Defer JSON column from loading when doing SQL sorting for computing cache keys

### DIFF
--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -279,6 +279,15 @@ class OrchestratorService_Sql:
             # TODO: It might be better to search for ContainerExecutions rather than ExecutionNodes.
             execution_candidates = session.scalars(
                 sql.select(bts.ExecutionNode)
+                .options(
+                    # Defer JSON column `task_spec` to reduce filesort sort buffer usage during ORDER BY.
+                    # `extra_data` JSON will be called later so not deferring to prevent N + 1 queries.
+                    #
+                    # Reference:
+                    # "unloaded columns by default will load themselves when accessed using lazy loading"
+                    # https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#using-defer-to-omit-specific-columns
+                    orm.defer(bts.ExecutionNode.task_spec),
+                )
                 .where(bts.ExecutionNode.container_execution_cache_key == cache_key)
                 .where(
                     bts.ExecutionNode.container_execution_status.in_(


### PR DESCRIPTION
### TL;DR

Defer the `task_spec` JSON column when querying `ExecutionNode` to reduce memory usage during sorted queries.

### What changed?

When querying `ExecutionNode` execution candidates, the `task_spec` JSON column is now deferred using SQLAlchemy's `orm.defer()`. The `extra_data` JSON column is intentionally left undeferred to avoid N+1 queries since it is accessed shortly after. `task_spec` will still be lazily loaded if accessed later, but is excluded from the initial query.

### Why make this change?

JSON columns can be large and contribute significantly to MySQL's sort buffer usage when an `ORDER BY` clause is involved. By deferring `task_spec`, the sort buffer footprint is reduced, which can prevent performance degradation or failures on queries that require filesort operations.

### How to test?

Run the existing orchestrator tests and verify that execution candidate lookups still function correctly, including cases where `task_spec` is accessed after the initial query.

### Test Steps
1. Ran pipeline with all node's cache disabled. Success.
2. Ran pipeline with all node's cache enabled (default). Success.