### PR TITLE
Wire Bugsnag into the API server

### DIFF
--- a/api_server_main.py
+++ b/api_server_main.py
@@ -1,11 +1,13 @@
 import os
 import traceback
 
+import bugsnag.middleware as bugsnag_middleware
 import fastapi
 
 from cloud_pipelines_backend import api_router
 from cloud_pipelines_backend import database_ops
 from cloud_pipelines_backend.instrumentation import api_tracing
+from cloud_pipelines_backend.instrumentation import bugsnag_instrumentation
 from cloud_pipelines_backend.instrumentation import contextual_logging
 from cloud_pipelines_backend.instrumentation import opentelemetry as otel
 
@@ -18,13 +20,19 @@ app = fastapi.FastAPI(
 otel.setup_providers()
 otel.instrument_fastapi(app)
 
+bugsnag_instrumentation.setup(service_name="tangle-api")
+
 # Add request context middleware for automatic request_id generation
 app.add_middleware(api_tracing.RequestContextMiddleware)
+
+if bugsnag_instrumentation.IS_BUGSNAG_ENABLED:
+    app.add_middleware(bugsnag_middleware.BugsnagMiddleware)
 
 
 @app.exception_handler(Exception)
 def handle_error(request: fastapi.Request, exc: BaseException):
     exception_str = traceback.format_exception(type(exc), exc, exc.__traceback__)
+    bugsnag_instrumentation.notify(exception=exc)
     response = fastapi.responses.JSONResponse(
         status_code=503,
         content={"exception": exception_str},


### PR DESCRIPTION
### TL;DR

Integrates Bugsnag error monitoring into the API server.

### What changed?

- Bugsnag is initialized during app startup with the service name `tangle-api`.
- The `BugsnagMiddleware` is conditionally added to the FastAPI middleware stack when Bugsnag is enabled.
- Unhandled exceptions caught by the global exception handler are now reported to Bugsnag via `bugsnag_instrumentation.notify`.

### How to test?

- Enable Bugsnag by configuring the appropriate environment variables/credentials.
- Trigger an unhandled exception in the API and verify it appears in the Bugsnag dashboard.
- Confirm the middleware is only added when `IS_BUGSNAG_ENABLED` is `True`, and that the app starts normally when Bugsnag is disabled.

### Why make this change?

To improve observability and error tracking in production by capturing and reporting unhandled exceptions to Bugsnag, enabling faster diagnosis and resolution of issues.

### Bugsnag ASGI Middleware

`BugsnagMiddleware` ([source](https://github.com/bugsnag/bugsnag-python/blob/master/bugsnag/asgi.py)) wraps the ASGI layer and automatically enriches every error event with request context:

- **Client IP** from the ASGI scope
- **HTTP method, version, and path**
- **Full request URL** (scheme + host + port + path + query string)
- **All request headers** — with `authorization`, `cookie`, `x-api-key`, and `proxy-authorization` redacted via `params_filters`
- **ASGI scope dict** as an `"environment"` tab — opt-in via `send_environment=True`, off by default

The middleware and the explicit `bugsnag.notify()` call in `handle_error` are complementary, not duplicative: FastAPI's exception handler consumes exceptions before they reach the ASGI layer, so `handle_error` covers normal request errors while `BugsnagMiddleware` acts as a safety net for exceptions that escape FastAPI entirely (e.g. startup failures, middleware crashes).

Additionally, every Bugsnag event — whether from the middleware or from a direct `notify()` call — is enriched with a `"tangle_context"` tab via our `before_notify` callback, containing: `request_id`, `user_id`, `pipeline_run_id`, and `execution_id` from the current request context.