### PR TITLE
Wire Bugsnag into the orchestrator

### DIFF
--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -21,6 +21,7 @@ from . import backend_types_sql as bts
 from . import component_structures as structures
 from .launchers import common_annotations
 from .launchers import interfaces as launcher_interfaces
+from .instrumentation import bugsnag_instrumentation
 from .instrumentation import contextual_logging
 from .instrumentation import metrics as app_metrics
 
@@ -66,8 +67,9 @@ class OrchestratorService_Sql:
             try:
                 self.process_each_queue_once()
                 time.sleep(self._sleep_seconds_between_queue_sweeps)
-            except Exception:
+            except Exception as exc:
                 _logger.exception("Error while calling `process_each_queue_once`")
+                bugsnag_instrumentation.notify(exception=exc)
 
     def process_each_queue_once(self):
         queue_handlers = [
@@ -78,8 +80,9 @@ class OrchestratorService_Sql:
             try:
                 with self._session_factory() as session:
                     queue_handler(session=session)
-            except Exception:
+            except Exception as exc:
                 _logger.exception(f"Error while executing {queue_handler=}")
+                bugsnag_instrumentation.notify(exception=exc)
 
     def internal_process_queued_executions_queue(self, session: orm.Session):
         query = (
@@ -1064,6 +1067,7 @@ def _retry(
 
 def record_system_error_exception(execution: bts.ExecutionNode, exception: Exception):
     app_metrics.execution_system_errors.add(1)
+    bugsnag_instrumentation.notify(exception=exception, execution_id=str(execution.id))
 
     if execution.extra_data is None:
         execution.extra_data = {}

--- a/orchestrator_main.py
+++ b/orchestrator_main.py
@@ -6,6 +6,7 @@ import sqlalchemy
 from sqlalchemy import orm
 
 from cloud_pipelines_backend import orchestrator_sql
+from cloud_pipelines_backend.instrumentation import bugsnag_instrumentation
 from cloud_pipelines_backend.launchers import kubernetes_launchers
 from cloud_pipelines.orchestration.storage_providers import local_storage
 
@@ -32,6 +33,7 @@ def main():
     logger.addHandler(stderr_handler)
 
     logger.info("Starting the orchestrator")
+    bugsnag_instrumentation.setup(service_name="tangle-orchestrator")
 
     DEFAULT_DATABASE_URI = "sqlite:///db.sqlite"
     database_uri = os.environ.get("DATABASE_URI", DEFAULT_DATABASE_URI)


### PR DESCRIPTION
### TL;DR

Integrates Bugsnag error reporting into the orchestrator to capture system-level exceptions.

### What changed?

Bugsnag instrumentation is now initialized at orchestrator startup with the service name `tangle-orchestrator`. System errors recorded via `record_system_error_exception` now notify Bugsnag with the associated execution ID. Additionally, any unhandled exception that escapes the main `run_loop` is reported to Bugsnag before being re-raised.

### How to test?

Trigger a system error during an execution and verify that the exception appears in Bugsnag with the correct execution ID attached. Also verify that an unhandled exception in `run_loop` is reported to Bugsnag under the `tangle-orchestrator` service.

### Why make this change?

Previously, system errors were only tracked via metrics and local logs, making it difficult to investigate failures in production. Routing these exceptions to Bugsnag provides better visibility and alerting for unexpected orchestrator errors.