### PR TITLE
Pin exclude-newer to 7-day window in pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       minor-patch-updates:
         update-types: ["minor", "patch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ huggingface = [
     "huggingface-hub[oauth]>=0.35.3",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "--import-mode=importlib"

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-05-01T21:43:53.304008Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "alembic"
 version = "1.18.4"


### PR DESCRIPTION
### TL;DR

Pins dependency resolution to exclude packages newer than 7 days old.

### What changed?

Added a `[tool.uv]` configuration block to `pyproject.toml` with `exclude-newer = "7 days"`, which instructs `uv` to ignore any packages released within the last 7 days during dependency resolution. The `uv.lock` file has been updated to reflect this constraint with a concrete timestamp cutoff.

### How to test?

Run `uv lock` and verify that the resolved packages in `uv.lock` do not include any releases newer than 7 days from the resolution date.

### Why make this change?

Newly published packages can sometimes introduce unexpected breakage before the broader ecosystem has had a chance to vet them. By excluding packages released within the last 7 days, dependency resolution becomes more stable and less likely to pull in freshly published versions that may contain bugs or breaking changes.