### PR TITLE
Add Bugsnag error grouping with stable normalized keys

### DIFF
--- a/cloud_pipelines_backend/instrumentation/bugsnag_instrumentation.py
+++ b/cloud_pipelines_backend/instrumentation/bugsnag_instrumentation.py
@@ -6,11 +6,12 @@ Provides entry points to configure Bugsnag and report exceptions.
 No-op if TANGLE_BUGSNAG_API_KEY is not set.
 
 Environment variables:
-    TANGLE_BUGSNAG_API_KEY        Required to enable Bugsnag reporting.
-    TANGLE_ENV                    Release stage (e.g. "staging", "production").
-    TANGLE_SERVICE_VERSION        App version tag (e.g. git SHA). Optional.
-    TANGLE_BUGSNAG_NOTIFY_ENDPOINT   Custom notify URL. Optional.
-    TANGLE_BUGSNAG_SESSIONS_ENDPOINT Custom sessions URL. Optional.
+    TANGLE_BUGSNAG_API_KEY             Required to enable Bugsnag reporting.
+    TANGLE_ENV                         Release stage (e.g. "staging", "production").
+    TANGLE_SERVICE_VERSION             App version tag (e.g. git SHA). Optional.
+    TANGLE_BUGSNAG_NOTIFY_ENDPOINT     Custom notify URL. Optional.
+    TANGLE_BUGSNAG_SESSIONS_ENDPOINT   Custom sessions URL. Optional.
+    TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY Metadata key for normalized error grouping. Optional.
 """
 
 import logging
@@ -21,6 +22,7 @@ import bugsnag as bugsnag_sdk
 import bugsnag.event as bugsnag_event
 
 from . import contextual_logging
+from . import error_normalization
 
 _logger = logging.getLogger(__name__)
 
@@ -29,6 +31,7 @@ _TANGLE_ENV = os.environ.get("TANGLE_ENV")
 _SERVICE_VERSION = os.environ.get("TANGLE_SERVICE_VERSION")
 _NOTIFY_ENDPOINT = os.environ.get("TANGLE_BUGSNAG_NOTIFY_ENDPOINT")
 _SESSIONS_ENDPOINT = os.environ.get("TANGLE_BUGSNAG_SESSIONS_ENDPOINT")
+_CUSTOM_GROUPING_KEY = os.environ.get("TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY")
 
 IS_BUGSNAG_ENABLED: bool = bool(_BUGSNAG_API_KEY)
 _setup_called: bool = False
@@ -39,6 +42,21 @@ def _before_notify(event: bugsnag_event.Event) -> None:
     context = contextual_logging.get_all_context_metadata()
     if context:
         event.add_tab("tangle_context", context)
+    if _CUSTOM_GROUPING_KEY and event.original_error:
+        normalized = error_normalization.normalize_error_message(
+            exception=event.original_error
+        )
+        prefix = (event.metadata.get("extra") or {}).get("grouping_prefix")
+        key_value = f"{prefix}: {normalized}" if prefix else normalized
+        event.add_tab("custom", {_CUSTOM_GROUPING_KEY: key_value})
+        if prefix and event.errors:
+            try:
+                for error in event.errors:
+                    error.error_class = f"{prefix}: {error.error_class}"
+            except Exception:
+                _logger.debug(
+                    "Could not prepend grouping prefix to errorClass", exc_info=True
+                )
 
 
 def setup(*, service_name: str | None = None) -> None:

--- a/cloud_pipelines_backend/instrumentation/error_normalization.py
+++ b/cloud_pipelines_backend/instrumentation/error_normalization.py
@@ -1,0 +1,100 @@
+"""
+Normalizes exception messages into stable strings for error grouping.
+
+Strips instance-specific values (pod names, IDs, memory addresses, byte
+offsets) so that structurally identical errors produce the same key
+regardless of which specific resource was involved.
+"""
+
+import json
+import re
+
+_POD_NAME_PATTERN = re.compile(r"(?:task|tangle(?:-ce)?)-[a-zA-Z0-9]+-[a-zA-Z0-9]+")
+_OBJECT_REPR_PATTERN = re.compile(r"<[^>]+ object at 0x[0-9a-fA-F]+>")
+_HEX_ADDRESS_PATTERN = re.compile(r"\b0x[0-9a-fA-F]+\b")
+_UUID_PATTERN = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
+)
+_LONG_ALNUM_ID_PATTERN = re.compile(r"\b[a-zA-Z0-9]{16,}\b")
+
+
+def _strip_generic(*, message: str) -> str:
+    message = _OBJECT_REPR_PATTERN.sub("{object}", message)
+    message = _HEX_ADDRESS_PATTERN.sub("{addr}", message)
+    message = _UUID_PATTERN.sub("{uuid}", message)
+    message = _LONG_ALNUM_ID_PATTERN.sub("{id}", message)
+    return message.strip()
+
+
+def _normalize_k8s_api_exception(*, exception: BaseException) -> str | None:
+    try:
+        from kubernetes.client import exceptions as k8s_exceptions
+
+        if not isinstance(exception, k8s_exceptions.ApiException):
+            return None
+    except ImportError:
+        return None
+
+    status_code = exception.status
+    try:
+        body = json.loads(exception.body)
+        reason = body.get("reason", "")
+        message = body.get("message", "")
+    except (json.JSONDecodeError, TypeError):
+        reason = ""
+        message = str(exception)
+
+    message = _POD_NAME_PATTERN.sub("{pod}", message)
+    parts = [f"kubernetes ApiException ({status_code})"]
+    if reason:
+        parts.append(reason)
+    if message:
+        parts.append(message)
+    return ": ".join(parts)
+
+
+def _normalize_max_retry_error(*, exception: BaseException) -> str | None:
+    try:
+        from urllib3.exceptions import MaxRetryError
+
+        if not isinstance(exception, MaxRetryError):
+            return None
+    except ImportError:
+        return None
+
+    cause = type(exception.reason).__name__ if exception.reason else "unknown"
+    return f"MaxRetryError: k8s connection pool max retries exceeded ({cause})"
+
+
+def _normalize_unicode_decode_error(*, exception: BaseException) -> str | None:
+    if not isinstance(exception, UnicodeDecodeError):
+        return None
+    return f"UnicodeDecodeError: '{exception.encoding}' codec can't decode byte at position {{n}}"
+
+
+def _normalize_orchestrator_error(*, exception: BaseException) -> str | None:
+    try:
+        from ..orchestrator_sql import OrchestratorError
+
+        if not isinstance(exception, OrchestratorError):
+            return None
+    except ImportError:
+        return None
+
+    message = _OBJECT_REPR_PATTERN.sub("{object}", str(exception))
+    return f"OrchestratorError: {message}"
+
+
+def normalize_error_message(*, exception: BaseException) -> str:
+    """Return a stable normalized string for error grouping."""
+    for normalizer in (
+        _normalize_k8s_api_exception,
+        _normalize_max_retry_error,
+        _normalize_unicode_decode_error,
+        _normalize_orchestrator_error,
+    ):
+        result = normalizer(exception=exception)
+        if result is not None:
+            return result
+
+    return f"{type(exception).__name__}: {_strip_generic(message=str(exception))}"

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -1067,7 +1067,11 @@ def _retry(
 
 def record_system_error_exception(execution: bts.ExecutionNode, exception: Exception):
     app_metrics.execution_system_errors.add(1)
-    bugsnag_instrumentation.notify(exception=exception, execution_id=str(execution.id))
+    bugsnag_instrumentation.notify(
+        exception=exception,
+        execution_id=str(execution.id),
+        grouping_prefix="SYSTEM_ERROR",
+    )
 
     if execution.extra_data is None:
         execution.extra_data = {}

--- a/tests/instrumentation/test_bugsnag.py
+++ b/tests/instrumentation/test_bugsnag.py
@@ -192,6 +192,85 @@ def test_before_notify_attaches_context_metadata(monkeypatch):
     )
 
 
+def test_before_notify_prefixes_error_class_when_grouping_prefix_set(monkeypatch):
+    monkeypatch.setenv("TANGLE_BUGSNAG_API_KEY", "test-api-key")
+    monkeypatch.setenv("TANGLE_ENV", "staging")
+    monkeypatch.setenv("TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY", "my_key")
+
+    import importlib
+    import cloud_pipelines_backend.instrumentation.bugsnag_instrumentation as bugsnag_module
+
+    importlib.reload(bugsnag_module)
+
+    from cloud_pipelines_backend.instrumentation import contextual_logging
+    from bugsnag.error import Error
+
+    contextual_logging.clear_context_metadata()
+
+    error = Error("ValueError", "boom", [])
+    mock_event = mock.MagicMock()
+    mock_event.original_error = ValueError("boom")
+    mock_event.metadata = {"extra": {"grouping_prefix": "SYSTEM_ERROR"}}
+    mock_event.errors = [error]
+
+    bugsnag_module._before_notify(mock_event)
+
+    assert error.error_class == "SYSTEM_ERROR: ValueError"
+
+
+def test_before_notify_skips_error_class_prefix_when_no_grouping_prefix(monkeypatch):
+    monkeypatch.setenv("TANGLE_BUGSNAG_API_KEY", "test-api-key")
+    monkeypatch.setenv("TANGLE_ENV", "staging")
+    monkeypatch.setenv("TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY", "my_key")
+
+    import importlib
+    import cloud_pipelines_backend.instrumentation.bugsnag_instrumentation as bugsnag_module
+
+    importlib.reload(bugsnag_module)
+
+    from cloud_pipelines_backend.instrumentation import contextual_logging
+    from bugsnag.error import Error
+
+    contextual_logging.clear_context_metadata()
+
+    error = Error("ValueError", "boom", [])
+    mock_event = mock.MagicMock()
+    mock_event.original_error = ValueError("boom")
+    mock_event.metadata = {"extra": {}}
+    mock_event.errors = [error]
+
+    bugsnag_module._before_notify(mock_event)
+
+    assert error.error_class == "ValueError"
+
+
+def test_before_notify_skips_error_class_prefix_gracefully_on_bad_errors_structure(
+    monkeypatch,
+):
+    monkeypatch.setenv("TANGLE_BUGSNAG_API_KEY", "test-api-key")
+    monkeypatch.setenv("TANGLE_ENV", "staging")
+    monkeypatch.setenv("TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY", "my_key")
+
+    import importlib
+    import cloud_pipelines_backend.instrumentation.bugsnag_instrumentation as bugsnag_module
+
+    importlib.reload(bugsnag_module)
+
+    from cloud_pipelines_backend.instrumentation import contextual_logging
+
+    contextual_logging.clear_context_metadata()
+
+    mock_event = mock.MagicMock()
+    mock_event.original_error = ValueError("boom")
+    mock_event.metadata = {"extra": {"grouping_prefix": "SYSTEM_ERROR"}}
+    mock_event.errors = (
+        "unexpected"  # SDK structure changed — not a list of Error objects
+    )
+
+    # Should not raise
+    bugsnag_module._before_notify(mock_event)
+
+
 def test_before_notify_skips_empty_context(monkeypatch):
     monkeypatch.setenv("TANGLE_BUGSNAG_API_KEY", "test-api-key")
     monkeypatch.setenv("TANGLE_ENV", "staging")

--- a/tests/instrumentation/test_error_normalization.py
+++ b/tests/instrumentation/test_error_normalization.py
@@ -1,0 +1,206 @@
+"""Tests for error_normalization module."""
+
+import json
+import unittest.mock as mock
+
+import pytest
+
+from cloud_pipelines_backend.instrumentation import error_normalization
+
+
+class TestNormalizeK8sApiException:
+    def _make_exception(self, status: int, body: dict) -> Exception:
+        try:
+            from kubernetes.client.exceptions import ApiException
+        except ImportError:
+            pytest.skip("kubernetes not installed")
+        exc = ApiException(status=status, reason=body.get("reason", ""))
+        exc.body = json.dumps(body)
+        return exc
+
+    def test_pod_not_found(self):
+        exc = self._make_exception(
+            404,
+            {
+                "reason": "NotFound",
+                "message": 'pods "task-abc123-xyz789" not found',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result == 'kubernetes ApiException (404): NotFound: pods "{pod}" not found'
+        )
+
+    def test_container_terminated(self):
+        exc = self._make_exception(
+            400,
+            {
+                "reason": "BadRequest",
+                "message": 'container "main" in pod task-abc123-xyz789 is terminated',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == 'kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is terminated'
+        )
+
+    def test_pod_initializing(self):
+        exc = self._make_exception(
+            400,
+            {
+                "reason": "BadRequest",
+                "message": 'container "main" in pod task-abc123-xyz789 is waiting to start: PodInitializing',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result == (
+            'kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is waiting to start: PodInitializing'
+        )
+
+    def test_container_not_available(self):
+        exc = self._make_exception(
+            400,
+            {
+                "reason": "BadRequest",
+                "message": 'container "main" in pod task-abc123-xyz789 is not available',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == 'kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is not available'
+        )
+
+    def test_webhook_timeout(self):
+        exc = self._make_exception(
+            500,
+            {
+                "reason": "InternalError",
+                "message": 'failed calling webhook "validate.kyverno.svc-fail": context deadline exceeded',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result == (
+            'kubernetes ApiException (500): InternalError: failed calling webhook "validate.kyverno.svc-fail": context deadline exceeded'
+        )
+
+    def test_pod_not_found_tangle_ce_prefix(self):
+        exc = self._make_exception(
+            404,
+            {
+                "reason": "NotFound",
+                "message": 'pods "tangle-ce-abc123-xyz789" not found',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result == 'kubernetes ApiException (404): NotFound: pods "{pod}" not found'
+        )
+
+    def test_pod_not_found_tangle_prefix(self):
+        exc = self._make_exception(
+            404,
+            {
+                "reason": "NotFound",
+                "message": 'pods "tangle-abc123-xyz789" not found',
+            },
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result == 'kubernetes ApiException (404): NotFound: pods "{pod}" not found'
+        )
+
+    def test_invalid_body_falls_back_to_str(self):
+        try:
+            from kubernetes.client.exceptions import ApiException
+        except ImportError:
+            pytest.skip("kubernetes not installed")
+        exc = ApiException(status=503, reason="ServiceUnavailable")
+        exc.body = "not json"
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result.startswith("kubernetes ApiException (503)")
+
+
+class TestNormalizeMaxRetryError:
+    def test_read_timeout(self):
+        try:
+            from urllib3.exceptions import MaxRetryError, ReadTimeoutError
+        except ImportError:
+            pytest.skip("urllib3 not installed")
+        cause = ReadTimeoutError(pool=None, url="/api/v1/pods", message="timed out")
+        exc = MaxRetryError(pool=None, url="http://10.0.0.1/api/v1/pods", reason=cause)
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == "MaxRetryError: k8s connection pool max retries exceeded (ReadTimeoutError)"
+        )
+
+    def test_no_cause(self):
+        try:
+            from urllib3.exceptions import MaxRetryError
+        except ImportError:
+            pytest.skip("urllib3 not installed")
+        exc = MaxRetryError(pool=None, url="http://10.0.0.1/api/v1/pods", reason=None)
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == "MaxRetryError: k8s connection pool max retries exceeded (unknown)"
+        )
+
+
+class TestNormalizeUnicodeDecodeError:
+    def test_strips_offset(self):
+        exc = UnicodeDecodeError("utf-8", b"\xff\xfe", 42, 43, "invalid start byte")
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == "UnicodeDecodeError: 'utf-8' codec can't decode byte at position {n}"
+        )
+
+    def test_different_encoding(self):
+        exc = UnicodeDecodeError("ascii", b"\x80", 0, 1, "ordinal not in range")
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result
+            == "UnicodeDecodeError: 'ascii' codec can't decode byte at position {n}"
+        )
+
+
+class TestNormalizeOrchestratorError:
+    def test_strips_object_repr(self):
+        try:
+            from cloud_pipelines_backend.orchestrator_sql import (
+                OrchestratorError,
+            )  # absolute OK in tests
+        except ImportError:
+            pytest.skip("OrchestratorError not importable")
+        exc = OrchestratorError(
+            "Unexpected running container status: <ContainerStatus object at 0xdeadbeef>"
+        )
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert (
+            result == "OrchestratorError: Unexpected running container status: {object}"
+        )
+
+
+class TestFallback:
+    def test_strips_hex_address(self):
+        exc = ValueError("object at 0xdeadbeef failed")
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result == "ValueError: object at {addr} failed"
+
+    def test_strips_uuid(self):
+        exc = RuntimeError("resource 550e8400-e29b-41d4-a716-446655440000 not found")
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result == "RuntimeError: resource {uuid} not found"
+
+    def test_strips_long_alnum_id(self):
+        exc = KeyError("abcdefghijklmnopq")  # 17 chars
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert "abcdefghijklmnopq" not in result
+
+    def test_stable_message_unchanged(self):
+        exc = AttributeError("'NoneType' object has no attribute 'encode'")
+        result = error_normalization.normalize_error_message(exception=exc)
+        assert result == "AttributeError: 'NoneType' object has no attribute 'encode'"


### PR DESCRIPTION
### Add Bugsnag error grouping with stable normalized keys

Introduces configurable error grouping so structurally identical exceptions collapse into a single group rather than creating a new entry per unique pod name, UUID, or memory address.

#### How it works

A new `TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY` env var controls the metadata key name written on each Bugsnag event. When unset the feature is a complete no-op. When set (by a deployment), every notified exception gets a `custom[<key>]` tab containing a normalized string derived from the exception type and message.

System errors reported through `record_system_error_exception` are additionally prefixed with `SYSTEM_ERROR: ` so they can be filtered or grouped separately from non-system errors.

#### Error taxonomy

The following exception types, from one consumer use case, are normalized to stable grouping keys:

| Group | Normalized key |
| --- | --- |
| k8s pod not found | `kubernetes ApiException (404): NotFound: pods "{pod}" not found` |
| k8s container terminated | `kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is terminated` |
| k8s pod initializing | `kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is waiting to start: PodInitializing` |
| k8s container not available | `kubernetes ApiException (400): BadRequest: container "main" in pod {pod} is not available` |
| k8s webhook timeout | `kubernetes ApiException (500): InternalError: failed calling webhook "<>": context deadline exceeded` |
| UnicodeDecodeError | `UnicodeDecodeError: 'utf-8' codec can't decode byte at position {n}` |
| MaxRetryError | `MaxRetryError: k8s connection pool max retries exceeded (ReadTimeoutError)` |
| OrchestratorError | `OrchestratorError: Unexpected running container status: {object}` |
| Fallback | `ExceptionType: {message with addresses/UUIDs/IDs stripped}` |

Many exception types (e.g. `AttributeError`, `sqlalchemy.exc.OperationalError`) already produce stable messages and pass through the fallback unchanged.

#### Changes

- **`error_normalization.py`** (new) — one public function `normalize_error_message(*, exception)` dispatching to type-specific handlers before falling back to a generic stripper that removes hex addresses, UUIDs, and long alphanumeric IDs
- **`bugsnag_instrumentation.py`** — reads `TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY`; `_before_notify` attaches the normalized key when configured; supports an optional `grouping_prefix` passed through `notify(**metadata)`
- **`orchestrator_sql.py`** — `record_system_error_exception` passes `grouping_prefix="SYSTEM_ERROR"` so system errors are visually distinct
- **`test_error_normalization.py`** (new) — 15 unit tests covering all error groups and the fallback path

#### OSS note

The grouping key name is not hardcoded — it is supplied entirely via `TANGLE_BUGSNAG_CUSTOM_GROUPING_KEY` at deploy time, so no internal platform names appear in OSS code.