### PR TITLE
Security: Sensitive Data Exposure in Error Response

### DIFF
--- a/api_server_main.py
+++ b/api_server_main.py
@@ -35,7 +35,7 @@ def handle_error(request: fastapi.Request, exc: BaseException):
     bugsnag_instrumentation.notify(exception=exc)
     response = fastapi.responses.JSONResponse(
         status_code=503,
-        content={"exception": exception_str},
+        content={"error": "An unexpected error occurred. Please try again later."},
     )
     request_id = contextual_logging.get_context_metadata("request_id")
     if request_id:


### PR DESCRIPTION
## Summary

Security: Sensitive Data Exposure in Error Response

## Problem

**Severity**: `High` | **File**: `api_server_main.py:L36`

In api_server_main.py, the exception handler returns full stack traces (traceback.format_exception) in the JSON response to clients. This exposes internal application details, file paths, and potentially sensitive configuration information.

## Solution

Return a generic error message to clients in production. Only log the full stack trace server-side. Consider using a separate error code that clients can use to look up details in documentation or a separate logging system.

## Changes

- `api_server_main.py` (modified)