### PR TITLE
Add multi-node runtime barrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ A **task** describes an instance of a component and specifies the input argument
 The resulting *graph* of interconnected tasks is called a *pipeline*.
 A pipeline can be submitted for *execution*. During the pipeline execution, the pipeline's tasks are executed (in parallel, if possible) and produce output artifacts that are passed to downstream tasks.
 
+## Multi-node runtime helpers
+
+Kubernetes-backed multi-node tasks receive runtime metadata through environment variables such as `TANGLE_MULTI_NODE_NUMBER_OF_NODES`, `TANGLE_MULTI_NODE_NODE_INDEX`, and `TANGLE_MULTI_NODE_NODE_0_ADDRESS`.
+Python component images that include this package can use the cooperative barrier helper when all nodes must reach the same phase before node 0 continues:
+
+```python
+from cloud_pipelines_backend.runtime import multi_node
+
+multi_node.barrier("training-finished", timeout_seconds=600)
+```
+
+The helper coordinates over the task's headless Kubernetes Service. It is a synchronization primitive for nodes in the same task, not an authentication boundary. Component images must include `cloud-pipelines-backend` for the helper import to be available; non-Python containers can use the injected environment variables to implement equivalent coordination.
+
 ## Design
 
 This backend consists of the API Server and the Orchestrator.

--- a/cloud_pipelines_backend/launchers/interfaces.py
+++ b/cloud_pipelines_backend/launchers/interfaces.py
@@ -134,6 +134,9 @@ class LaunchedContainer(abc.ABC):
     def stream_log_lines(self) -> typing.Iterator[str]:
         raise NotImplementedError()
 
+    def cleanup(self) -> None:
+        pass
+
     def terminate(self) -> None:
         raise NotImplementedError()
 

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import secrets
 import typing
 from typing import Any, Optional
 
@@ -19,6 +20,7 @@ from cloud_pipelines.orchestration.storage_providers import (
 )
 from cloud_pipelines.orchestration.storage_providers import local_storage
 from .. import component_structures as structures
+from ..runtime import multi_node as multi_node_runtime
 from . import common_annotations
 from . import container_component_utils
 from . import interfaces
@@ -73,6 +75,8 @@ _MULTI_NODE_NODE_INDEX_ENV_VAR_NAME = "_TANGLE_MULTI_NODE_NODE_INDEX"
 _T = typing.TypeVar("_T")
 
 _CONTAINER_FILE_NAME = "data"
+_REDACTED_VALUE = "[REDACTED]"
+_SENSITIVE_ENV_VAR_NAME_PARTS = ("PASSWORD", "SECRET", "TOKEN")
 
 
 def _create_volume_and_volume_mount_host_path(
@@ -144,6 +148,25 @@ def _create_volume_and_volume_mount_google_cloud_storage(
             sub_path=sub_path,
         ),
     )
+
+
+def _delete_namespaced_service_if_exists(
+    *,
+    core_api_client: k8s_client_lib.CoreV1Api,
+    name: str,
+    namespace: str,
+    request_timeout: int | tuple[int, int],
+) -> None:
+    try:
+        core_api_client.delete_namespaced_service(
+            name=name,
+            namespace=namespace,
+            _request_timeout=request_timeout,
+        )
+    except kubernetes.client.exceptions.ApiException as ex:
+        if ex.status == 404:
+            return
+        raise
 
 
 class PodPostProcessor(typing.Protocol):
@@ -1073,6 +1096,7 @@ class _KubernetesJobLauncher(
         else:
             node_0_address = "localhost"
             all_node_addresses_str = node_0_address
+        multi_node_barrier_token = secrets.token_hex(16)
 
         # Resolving the dynamic data arguments
         known_dynamic_data_values = {
@@ -1127,6 +1151,20 @@ class _KubernetesJobLauncher(
         if enable_multi_node:
             main_container_spec = pod.spec.containers[0]
             main_container_spec.env = main_container_spec.env or []
+            runtime_env_names = {
+                _MULTI_NODE_NODE_INDEX_ENV_VAR_NAME,
+                multi_node_runtime.NUMBER_OF_NODES_ENV_VAR_NAME,
+                multi_node_runtime.NODE_INDEX_ENV_VAR_NAME,
+                multi_node_runtime.NODE_0_ADDRESS_ENV_VAR_NAME,
+                multi_node_runtime.ALL_NODE_ADDRESSES_ENV_VAR_NAME,
+                multi_node_runtime.BARRIER_PORT_ENV_VAR_NAME,
+                multi_node_runtime.BARRIER_TOKEN_ENV_VAR_NAME,
+            }
+            main_container_spec.env = [
+                env_var
+                for env_var in main_container_spec.env
+                if env_var.name not in runtime_env_names
+            ]
 
             # We need to insert this env variable at the start on the list since subsequent variables can depend on it.
             main_container_spec.env.insert(
@@ -1143,6 +1181,34 @@ class _KubernetesJobLauncher(
                     ),
                 ),
             )
+            main_container_spec.env.extend(
+                [
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.NUMBER_OF_NODES_ENV_VAR_NAME,
+                        value=str(num_nodes),
+                    ),
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.NODE_INDEX_ENV_VAR_NAME,
+                        value=f"$({_MULTI_NODE_NODE_INDEX_ENV_VAR_NAME})",
+                    ),
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.NODE_0_ADDRESS_ENV_VAR_NAME,
+                        value=node_0_address,
+                    ),
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.ALL_NODE_ADDRESSES_ENV_VAR_NAME,
+                        value=all_node_addresses_str,
+                    ),
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.BARRIER_PORT_ENV_VAR_NAME,
+                        value=str(multi_node_runtime.DEFAULT_BARRIER_PORT),
+                    ),
+                    k8s_client_lib.V1EnvVar(
+                        name=multi_node_runtime.BARRIER_TOKEN_ENV_VAR_NAME,
+                        value=multi_node_barrier_token,
+                    ),
+                ]
+            )
             # Handling cross-pod communication.
             # Creating headless Kubernetes Service to give all pods in the job a stable DNS name to communicate with each other.
             service = k8s_client_lib.V1Service(
@@ -1156,6 +1222,14 @@ class _KubernetesJobLauncher(
                     selector={
                         "job-name": explicit_job_name,
                     },
+                    ports=[
+                        k8s_client_lib.V1ServicePort(
+                            name="barrier",
+                            port=multi_node_runtime.DEFAULT_BARRIER_PORT,
+                            target_port=multi_node_runtime.DEFAULT_BARRIER_PORT,
+                        )
+                    ],
+                    publish_not_ready_addresses=True,
                 ),
             )
             core_api_client = k8s_client_lib.CoreV1Api(api_client=self._api_client)
@@ -1207,6 +1281,20 @@ class _KubernetesJobLauncher(
                 _request_timeout=self._request_timeout,
             )
         except Exception as ex:
+            if enable_multi_node:
+                try:
+                    _delete_namespaced_service_if_exists(
+                        core_api_client=core_api_client,
+                        name=explicit_service_name,
+                        namespace=namespace,
+                        request_timeout=self._request_timeout,
+                    )
+                except Exception:
+                    _logger.warning(
+                        "Failed to delete Kubernetes Service %s after Job creation failed.",
+                        explicit_service_name,
+                        exc_info=True,
+                    )
             raise interfaces.LauncherError(
                 f"Failed to create Kubernetes Job: {_kubernetes_serialize(job)}"
             ) from ex
@@ -1584,15 +1672,30 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
 
         return pprint.pformat(self.to_dict())
 
+    def cleanup(self) -> None:
+        launcher = self._get_launcher()
+        core_api_client = k8s_client_lib.CoreV1Api(api_client=launcher._api_client)
+        _delete_namespaced_service_if_exists(
+            core_api_client=core_api_client,
+            name=self._job_name,
+            namespace=self._namespace,
+            request_timeout=launcher._request_timeout,
+        )
+
     def terminate(self):
         launcher = self._get_launcher()
         batch_api_client = k8s_client_lib.BatchV1Api(api_client=launcher._api_client)
-        batch_api_client.delete_namespaced_job(
-            name=self._job_name,
-            namespace=self._namespace,
-            grace_period_seconds=10,
-            propagation_policy="Foreground",
-        )
+        try:
+            batch_api_client.delete_namespaced_job(
+                name=self._job_name,
+                namespace=self._namespace,
+                grace_period_seconds=10,
+                propagation_policy="Foreground",
+            )
+        except kubernetes.client.exceptions.ApiException as ex:
+            if ex.status != 404:
+                raise
+        self.cleanup()
         _logger.info(f"Terminated job {self._job_name} in namespace {self._namespace}")
 
 
@@ -1779,7 +1882,30 @@ def windows_path_to_docker_path(path: str) -> str:
 
 def _kubernetes_serialize(obj) -> dict[str, Any]:
     shallow_client = k8s_client_lib.ApiClient.__new__(k8s_client_lib.ApiClient)
-    return shallow_client.sanitize_for_serialization(obj)
+    serialized = shallow_client.sanitize_for_serialization(obj)
+    _redact_sensitive_env_values(serialized)
+    return serialized
+
+
+def _redact_sensitive_env_values(value: Any) -> None:
+    if isinstance(value, dict):
+        env_name = value.get("name")
+        if (
+            isinstance(env_name, str)
+            and "value" in value
+            and _is_sensitive_env_var_name(env_name)
+        ):
+            value["value"] = _REDACTED_VALUE
+        for child_value in value.values():
+            _redact_sensitive_env_values(child_value)
+    elif isinstance(value, list):
+        for item in value:
+            _redact_sensitive_env_values(item)
+
+
+def _is_sensitive_env_var_name(name: str) -> bool:
+    upper_name = name.upper()
+    return any(part in upper_name for part in _SENSITIVE_ENV_VAR_NAME_PARTS)
 
 
 def _kubernetes_deserialize(obj_dict: dict[str, Any], cls: typing.Type[_T]) -> _T:

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -745,6 +745,11 @@ class OrchestratorService_Sql:
         )
         session.rollback()
         container_execution.updated_at = current_time
+        if new_status in (
+            launcher_interfaces.ContainerStatus.SUCCEEDED,
+            launcher_interfaces.ContainerStatus.FAILED,
+        ):
+            _cleanup_launched_container(reloaded_launched_container)
         execution_nodes = container_execution.execution_nodes
         if not execution_nodes:
             raise OrchestratorError(
@@ -1063,6 +1068,15 @@ def _retry(
             if i == max_retries - 1:
                 raise
     raise
+
+
+def _cleanup_launched_container(
+    launched_container: launcher_interfaces.LaunchedContainer,
+) -> None:
+    try:
+        _retry(launched_container.cleanup)
+    except Exception:
+        _logger.exception("Error during `LaunchedContainer.cleanup` call.")
 
 
 def record_system_error_exception(execution: bts.ExecutionNode, exception: Exception):

--- a/cloud_pipelines_backend/runtime/__init__.py
+++ b/cloud_pipelines_backend/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime helpers for Tangle component containers."""
+
+from . import multi_node
+
+__all__ = ["multi_node"]

--- a/cloud_pipelines_backend/runtime/multi_node.py
+++ b/cloud_pipelines_backend/runtime/multi_node.py
@@ -1,0 +1,526 @@
+"""Runtime helpers for Tangle multi-node component containers."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import socket
+import time
+from collections.abc import Iterable, Mapping
+from typing import Any, Final
+
+NUMBER_OF_NODES_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_NUMBER_OF_NODES"
+NODE_INDEX_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_NODE_INDEX"
+NODE_0_ADDRESS_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_NODE_0_ADDRESS"
+ALL_NODE_ADDRESSES_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_ALL_NODE_ADDRESSES"
+BARRIER_TOKEN_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_BARRIER_TOKEN"
+BARRIER_PORT_ENV_VAR_NAME: Final = "TANGLE_MULTI_NODE_BARRIER_PORT"
+
+DEFAULT_BARRIER_PORT: Final = 34855
+DEFAULT_BARRIER_TIMEOUT_SECONDS: Final = 600.0
+DEFAULT_CONNECT_RETRY_INTERVAL_SECONDS: Final = 1.0
+
+_MAX_MESSAGE_BYTES: Final = 64 * 1024
+_PROTOCOL_VERSION: Final = 1
+_REQUEST_READ_TIMEOUT_SECONDS: Final = 5.0
+_LISTENER_POLL_SECONDS: Final = 0.2
+
+__all__ = [
+    "ALL_NODE_ADDRESSES_ENV_VAR_NAME",
+    "BARRIER_PORT_ENV_VAR_NAME",
+    "BARRIER_TOKEN_ENV_VAR_NAME",
+    "DEFAULT_BARRIER_PORT",
+    "DEFAULT_BARRIER_TIMEOUT_SECONDS",
+    "DEFAULT_CONNECT_RETRY_INTERVAL_SECONDS",
+    "MultiNodeBarrierError",
+    "MultiNodeBarrierTimeoutError",
+    "MultiNodeConfig",
+    "MultiNodeConfigurationError",
+    "NODE_0_ADDRESS_ENV_VAR_NAME",
+    "NODE_INDEX_ENV_VAR_NAME",
+    "NUMBER_OF_NODES_ENV_VAR_NAME",
+    "barrier",
+]
+
+
+class MultiNodeConfigurationError(ValueError):
+    """Raised when multi-node runtime configuration is invalid."""
+
+
+class MultiNodeBarrierError(RuntimeError):
+    """Raised when a multi-node barrier cannot complete."""
+
+
+class MultiNodeBarrierTimeoutError(MultiNodeBarrierError):
+    """Raised when a multi-node barrier does not complete before its deadline."""
+
+
+class _BarrierRejectedError(MultiNodeBarrierError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class MultiNodeConfig:
+    """Configuration injected into a Tangle multi-node component container."""
+
+    number_of_nodes: int
+    node_index: int
+    node_0_address: str
+    all_node_addresses: tuple[str, ...]
+    barrier_token: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "all_node_addresses", tuple(self.all_node_addresses))
+        self._validate()
+
+    @classmethod
+    def from_env(cls, environ: Mapping[str, str] | None = None) -> "MultiNodeConfig":
+        env = os.environ if environ is None else environ
+        node_0_address = env.get(NODE_0_ADDRESS_ENV_VAR_NAME, "localhost")
+        all_node_addresses = tuple(
+            address.strip()
+            for address in env.get(
+                ALL_NODE_ADDRESSES_ENV_VAR_NAME,
+                node_0_address,
+            ).split(",")
+        )
+        return cls(
+            number_of_nodes=_parse_int_env(
+                env,
+                NUMBER_OF_NODES_ENV_VAR_NAME,
+                default=1,
+            ),
+            node_index=_parse_int_env(
+                env,
+                NODE_INDEX_ENV_VAR_NAME,
+                default=0,
+            ),
+            node_0_address=node_0_address,
+            all_node_addresses=all_node_addresses,
+            barrier_token=env.get(BARRIER_TOKEN_ENV_VAR_NAME, ""),
+        )
+
+    @property
+    def is_multi_node(self) -> bool:
+        return self.number_of_nodes > 1
+
+    def _validate(self) -> None:
+        if not _is_int(self.number_of_nodes) or self.number_of_nodes < 1:
+            raise MultiNodeConfigurationError(
+                f"{NUMBER_OF_NODES_ENV_VAR_NAME} must be a positive integer; got {self.number_of_nodes!r}."
+            )
+        if not _is_int(self.node_index):
+            raise MultiNodeConfigurationError(
+                f"{NODE_INDEX_ENV_VAR_NAME} must be an integer; got {self.node_index!r}."
+            )
+        if not 0 <= self.node_index < self.number_of_nodes:
+            raise MultiNodeConfigurationError(
+                f"{NODE_INDEX_ENV_VAR_NAME} must be between 0 and {self.number_of_nodes - 1}; got {self.node_index}."
+            )
+        if len(self.all_node_addresses) != self.number_of_nodes:
+            raise MultiNodeConfigurationError(
+                f"{ALL_NODE_ADDRESSES_ENV_VAR_NAME} must contain {self.number_of_nodes} addresses; got {len(self.all_node_addresses)}."
+            )
+        if not self.node_0_address:
+            raise MultiNodeConfigurationError(
+                f"{NODE_0_ADDRESS_ENV_VAR_NAME} must not be empty."
+            )
+        if any(not address for address in self.all_node_addresses):
+            raise MultiNodeConfigurationError(
+                f"{ALL_NODE_ADDRESSES_ENV_VAR_NAME} must not contain empty addresses."
+            )
+        if self.is_multi_node and not self.barrier_token:
+            raise MultiNodeConfigurationError(
+                f"{BARRIER_TOKEN_ENV_VAR_NAME} is required for multi-node barriers."
+            )
+
+
+def barrier(
+    name: str = "default",
+    *,
+    timeout_seconds: float = DEFAULT_BARRIER_TIMEOUT_SECONDS,
+    port: int | None = None,
+    config: MultiNodeConfig | None = None,
+    connect_retry_interval_seconds: float = DEFAULT_CONNECT_RETRY_INTERVAL_SECONDS,
+) -> None:
+    """Block until every node in the current Tangle multi-node task reaches the barrier."""
+
+    if not name:
+        raise ValueError("Barrier name must not be empty.")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive.")
+    if connect_retry_interval_seconds <= 0:
+        raise ValueError("connect_retry_interval_seconds must be positive.")
+    if port is not None and not 0 < port < 65536:
+        raise ValueError("port must be between 1 and 65535.")
+
+    config = config or MultiNodeConfig.from_env()
+    if not config.is_multi_node:
+        return
+
+    if port is None:
+        port = _parse_int_env(
+            os.environ,
+            BARRIER_PORT_ENV_VAR_NAME,
+            default=DEFAULT_BARRIER_PORT,
+        )
+    if not 0 < port < 65536:
+        raise ValueError("port must be between 1 and 65535.")
+
+    deadline = time.monotonic() + timeout_seconds
+    if config.node_index == 0:
+        _coordinate_barrier(
+            config=config,
+            name=name,
+            port=port,
+            deadline=deadline,
+            timeout_seconds=timeout_seconds,
+        )
+    else:
+        _join_barrier(
+            config=config,
+            name=name,
+            port=port,
+            deadline=deadline,
+            timeout_seconds=timeout_seconds,
+            connect_retry_interval_seconds=connect_retry_interval_seconds,
+        )
+
+
+def _coordinate_barrier(
+    *,
+    config: MultiNodeConfig,
+    name: str,
+    port: int,
+    deadline: float,
+    timeout_seconds: float,
+) -> None:
+    pending_node_indexes = set(range(1, config.number_of_nodes))
+    connections_by_node_index: dict[int, socket.socket] = {}
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        try:
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind(("", port))
+            listener.listen(max(1, config.number_of_nodes - 1))
+        except OSError as ex:
+            raise MultiNodeBarrierError(
+                f"Failed to listen for multi-node barrier {name!r} on port {port}."
+            ) from ex
+
+        try:
+            while pending_node_indexes:
+                remaining_seconds = _remaining_seconds(deadline)
+                if remaining_seconds <= 0:
+                    break
+                listener.settimeout(min(_LISTENER_POLL_SECONDS, remaining_seconds))
+                try:
+                    connection, _ = listener.accept()
+                except socket.timeout:
+                    continue
+
+                node_index = _accept_barrier_request(
+                    connection=connection,
+                    config=config,
+                    name=name,
+                    deadline=min(
+                        deadline,
+                        time.monotonic() + _REQUEST_READ_TIMEOUT_SECONDS,
+                    ),
+                )
+                if node_index is None:
+                    continue
+                if node_index not in pending_node_indexes:
+                    _reject_connection(
+                        connection,
+                        name=name,
+                        error=(
+                            f"Unexpected node index {node_index} for barrier {name!r}; "
+                            f"still waiting for {sorted(pending_node_indexes)}."
+                        ),
+                    )
+                    continue
+
+                connections_by_node_index[node_index] = connection
+                pending_node_indexes.remove(node_index)
+
+            if pending_node_indexes:
+                message = _timeout_message(
+                    name=name,
+                    timeout_seconds=timeout_seconds,
+                    missing_node_indexes=sorted(pending_node_indexes),
+                )
+                _send_error_to_connections(
+                    connections_by_node_index.values(),
+                    name=name,
+                    error=message,
+                )
+                raise MultiNodeBarrierTimeoutError(message)
+
+            _release_connections(connections_by_node_index, name=name)
+        finally:
+            for connection in connections_by_node_index.values():
+                connection.close()
+
+
+def _join_barrier(
+    *,
+    config: MultiNodeConfig,
+    name: str,
+    port: int,
+    deadline: float,
+    timeout_seconds: float,
+    connect_retry_interval_seconds: float,
+) -> None:
+    request_payload = _request_payload(config=config, name=name)
+    last_error: BaseException | None = None
+
+    while _remaining_seconds(deadline) > 0:
+        try:
+            timeout = min(connect_retry_interval_seconds, _remaining_seconds(deadline))
+            with socket.create_connection(
+                (config.node_0_address, port),
+                timeout=timeout,
+            ) as connection:
+                _send_json_line(connection, request_payload)
+                response_payload = _recv_json_line(connection, deadline=deadline)
+                _validate_response(response_payload, name=name)
+                return
+        except _BarrierRejectedError:
+            raise
+        except (OSError, MultiNodeBarrierError) as ex:
+            last_error = ex
+            sleep_seconds = min(
+                connect_retry_interval_seconds,
+                max(0.0, _remaining_seconds(deadline)),
+            )
+            if sleep_seconds > 0:
+                time.sleep(sleep_seconds)
+
+    message = _timeout_message(
+        name=name,
+        timeout_seconds=timeout_seconds,
+        missing_node_indexes=[config.node_index],
+    )
+    if last_error:
+        message = f"{message} Last error while contacting node 0 at {config.node_0_address}:{port}: {last_error}"
+    raise MultiNodeBarrierTimeoutError(message)
+
+
+def _accept_barrier_request(
+    *,
+    connection: socket.socket,
+    config: MultiNodeConfig,
+    name: str,
+    deadline: float,
+) -> int | None:
+    try:
+        payload = _recv_json_line(connection, deadline=deadline)
+        return _validate_request(payload, config=config, name=name)
+    except MultiNodeBarrierError as ex:
+        _reject_connection(connection, name=name, error=str(ex))
+        return None
+
+
+def _validate_request(
+    payload: Any,
+    *,
+    config: MultiNodeConfig,
+    name: str,
+) -> int:
+    if not isinstance(payload, dict):
+        raise MultiNodeBarrierError("Barrier request payload must be a JSON object.")
+    if payload.get("version") != _PROTOCOL_VERSION:
+        raise MultiNodeBarrierError("Barrier request protocol version does not match.")
+    if payload.get("type") != "barrier":
+        raise MultiNodeBarrierError("Barrier request type does not match.")
+    if payload.get("name") != name:
+        raise MultiNodeBarrierError(
+            f"Barrier request name {payload.get('name')!r} does not match {name!r}."
+        )
+    if payload.get("token") != config.barrier_token:
+        raise MultiNodeBarrierError("Barrier request token does not match.")
+    if payload.get("number_of_nodes") != config.number_of_nodes:
+        raise MultiNodeBarrierError(
+            "Barrier request number_of_nodes does not match the coordinator."
+        )
+
+    node_index = payload.get("node_index")
+    if not _is_int(node_index):
+        raise MultiNodeBarrierError("Barrier request node_index must be an integer.")
+    if not 0 <= node_index < config.number_of_nodes:
+        raise MultiNodeBarrierError(
+            f"Barrier request node_index must be between 0 and {config.number_of_nodes - 1}; got {node_index}."
+        )
+    return node_index
+
+
+def _validate_response(payload: Any, *, name: str) -> None:
+    if not isinstance(payload, dict):
+        raise _BarrierRejectedError("Barrier response payload must be a JSON object.")
+    if payload.get("version") != _PROTOCOL_VERSION:
+        raise _BarrierRejectedError("Barrier response protocol version does not match.")
+    if payload.get("name") != name:
+        raise _BarrierRejectedError(
+            f"Barrier response name {payload.get('name')!r} does not match {name!r}."
+        )
+    status = payload.get("status")
+    if status == "ok":
+        return
+    if status == "error":
+        raise _BarrierRejectedError(str(payload.get("error") or "Barrier failed."))
+    raise _BarrierRejectedError(f"Barrier response status {status!r} is not supported.")
+
+
+def _request_payload(*, config: MultiNodeConfig, name: str) -> dict[str, Any]:
+    return {
+        "version": _PROTOCOL_VERSION,
+        "type": "barrier",
+        "name": name,
+        "token": config.barrier_token,
+        "number_of_nodes": config.number_of_nodes,
+        "node_index": config.node_index,
+    }
+
+
+def _response_payload(
+    *,
+    name: str,
+    status: str,
+    error: str | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "version": _PROTOCOL_VERSION,
+        "name": name,
+        "status": status,
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+def _reject_connection(connection: socket.socket, *, name: str, error: str) -> None:
+    try:
+        _send_json_line(
+            connection,
+            _response_payload(name=name, status="error", error=error),
+        )
+    except OSError:
+        pass
+    finally:
+        try:
+            connection.close()
+        except OSError:
+            pass
+
+
+def _release_connections(
+    connections_by_node_index: Mapping[int, socket.socket],
+    *,
+    name: str,
+) -> None:
+    release_errors: list[str] = []
+    for node_index, connection in connections_by_node_index.items():
+        try:
+            _send_json_line(connection, _response_payload(name=name, status="ok"))
+        except OSError as ex:
+            release_errors.append(f"node {node_index}: {ex}")
+    if release_errors:
+        raise MultiNodeBarrierError(
+            "Failed to release every node from multi-node barrier "
+            f"{name!r}: {', '.join(release_errors)}"
+        )
+
+
+def _send_error_to_connections(
+    connections: Iterable[socket.socket],
+    *,
+    name: str,
+    error: str,
+) -> None:
+    for connection in connections:
+        try:
+            _send_json_line(
+                connection,
+                _response_payload(name=name, status="error", error=error),
+            )
+        except OSError:
+            pass
+
+
+def _send_json_line(connection: socket.socket, payload: dict[str, Any]) -> None:
+    connection.sendall(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8") + b"\n"
+    )
+
+
+def _recv_json_line(connection: socket.socket, *, deadline: float) -> Any:
+    chunks: list[bytes] = []
+    total_bytes = 0
+
+    while True:
+        remaining_seconds = _remaining_seconds(deadline)
+        if remaining_seconds <= 0:
+            raise MultiNodeBarrierTimeoutError("Timed out waiting for barrier message.")
+        connection.settimeout(remaining_seconds)
+        try:
+            chunk = connection.recv(4096)
+        except socket.timeout as ex:
+            raise MultiNodeBarrierTimeoutError(
+                "Timed out waiting for barrier message."
+            ) from ex
+        except OSError as ex:
+            raise MultiNodeBarrierError(
+                "Error while reading barrier message from connection."
+            ) from ex
+        if not chunk:
+            raise MultiNodeBarrierError(
+                "Connection closed before a barrier message arrived."
+            )
+
+        total_bytes += len(chunk)
+        if total_bytes > _MAX_MESSAGE_BYTES:
+            raise MultiNodeBarrierError("Barrier message exceeded maximum size.")
+        chunks.append(chunk)
+
+        if b"\n" in chunk:
+            break
+
+    message = b"".join(chunks).split(b"\n", 1)[0]
+    try:
+        return json.loads(message.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as ex:
+        raise MultiNodeBarrierError("Barrier message is not valid JSON.") from ex
+
+
+def _parse_int_env(env: Mapping[str, str], name: str, *, default: int) -> int:
+    raw_value = env.get(name)
+    if raw_value is None or raw_value == "":
+        return default
+    try:
+        return int(raw_value)
+    except ValueError as ex:
+        raise MultiNodeConfigurationError(
+            f"{name} must be an integer; got {raw_value!r}."
+        ) from ex
+
+
+def _is_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _remaining_seconds(deadline: float) -> float:
+    return deadline - time.monotonic()
+
+
+def _timeout_message(
+    *,
+    name: str,
+    timeout_seconds: float,
+    missing_node_indexes: list[int],
+) -> str:
+    return (
+        f"Timed out after {timeout_seconds:g}s waiting for multi-node barrier {name!r}; "
+        f"missing node indexes: {missing_node_indexes}."
+    )

--- a/tests/test_kubernetes_multi_node.py
+++ b/tests/test_kubernetes_multi_node.py
@@ -1,0 +1,198 @@
+import json
+from unittest import mock
+
+import pytest
+from kubernetes import client as k8s_client_lib
+
+from cloud_pipelines_backend import component_structures
+from cloud_pipelines_backend.launchers import common_annotations
+from cloud_pipelines_backend.launchers import kubernetes_launchers
+from cloud_pipelines_backend.runtime import multi_node
+
+
+def test_kubernetes_job_launcher_injects_multi_node_runtime_env_and_service():
+    api_client = mock.MagicMock()
+    api_client.configuration.host = "https://cluster.example"
+    fake_barrier_token = "fake-barrier-token"
+
+    def create_job(*, namespace, body, _request_timeout):
+        del namespace, _request_timeout
+        return body
+
+    with (
+        mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "VersionApi"
+        ) as version_api,
+        mock.patch.object(kubernetes_launchers.k8s_client_lib, "CoreV1Api") as core_api,
+        mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "BatchV1Api"
+        ) as batch_api,
+        mock.patch.object(
+            kubernetes_launchers.secrets,
+            "token_hex",
+            return_value=fake_barrier_token,
+        ),
+    ):
+        version_api.return_value.get_code.return_value = object()
+        batch_api.return_value.create_namespaced_job.side_effect = create_job
+        launcher = kubernetes_launchers.Local_Kubernetes_UsingHostPathStorage_KubernetesJobLauncher(
+            api_client=api_client,
+            namespace="default",
+        )
+
+        launched_container = launcher.launch_container_task(
+            component_spec=component_structures.ComponentSpec(
+                implementation=component_structures.ContainerImplementation(
+                    container=component_structures.ContainerSpec(
+                        image="python:3.12",
+                        command=["python"],
+                        args=["-c", "print('hello')"],
+                        env={
+                            multi_node.NUMBER_OF_NODES_ENV_VAR_NAME: "stale",
+                            "USER_ENV": "kept",
+                        },
+                    )
+                )
+            ),
+            input_arguments={},
+            output_uris={},
+            log_uri="file:///tmp/logs/execution-123",
+            annotations={
+                common_annotations.CONTAINER_EXECUTION_ID_ANNOTATION_KEY: "execution-123",
+                kubernetes_launchers.MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY: "3",
+            },
+        )
+        launched_container.terminate()
+
+    service = core_api.return_value.create_namespaced_service.call_args.kwargs["body"]
+    assert service.metadata.name == "tangle-ce-execution-123"
+    assert service.spec.cluster_ip == "None"
+    assert service.spec.selector == {"job-name": "tangle-ce-execution-123"}
+    assert service.spec.ports[0].name == "barrier"
+    assert service.spec.ports[0].port == multi_node.DEFAULT_BARRIER_PORT
+    assert service.spec.ports[0].target_port == multi_node.DEFAULT_BARRIER_PORT
+    assert service.spec.publish_not_ready_addresses is True
+    core_api.return_value.delete_namespaced_service.assert_called_once_with(
+        name="tangle-ce-execution-123",
+        namespace="default",
+        _request_timeout=10,
+    )
+
+    job = batch_api.return_value.create_namespaced_job.call_args.kwargs["body"]
+    pod_spec = job.spec.template.spec
+    assert pod_spec.subdomain == "tangle-ce-execution-123"
+    env_by_name = {env_var.name: env_var for env_var in pod_spec.containers[0].env}
+
+    assert env_by_name["USER_ENV"].value == "kept"
+    assert env_by_name[multi_node.NUMBER_OF_NODES_ENV_VAR_NAME].value == "3"
+    assert (
+        env_by_name[multi_node.NODE_INDEX_ENV_VAR_NAME].value
+        == "$(_TANGLE_MULTI_NODE_NODE_INDEX)"
+    )
+    assert (
+        env_by_name[multi_node.NODE_0_ADDRESS_ENV_VAR_NAME].value
+        == "tangle-ce-execution-123-0.tangle-ce-execution-123"
+    )
+    assert env_by_name[multi_node.ALL_NODE_ADDRESSES_ENV_VAR_NAME].value == (
+        "tangle-ce-execution-123-0.tangle-ce-execution-123,"
+        "tangle-ce-execution-123-1.tangle-ce-execution-123,"
+        "tangle-ce-execution-123-2.tangle-ce-execution-123"
+    )
+    assert env_by_name[multi_node.BARRIER_PORT_ENV_VAR_NAME].value == str(
+        multi_node.DEFAULT_BARRIER_PORT
+    )
+    assert (
+        env_by_name[multi_node.BARRIER_TOKEN_ENV_VAR_NAME].value == fake_barrier_token
+    )
+    serialized_launcher_data = json.dumps(launched_container.to_dict())
+    assert fake_barrier_token not in serialized_launcher_data
+    assert '"value": "[REDACTED]"' in serialized_launcher_data
+    assert (
+        env_by_name["_TANGLE_MULTI_NODE_NODE_INDEX"].value_from.field_ref.field_path
+        == "metadata.annotations['batch.kubernetes.io/job-completion-index']"
+    )
+
+
+def test_kubernetes_job_terminate_deletes_service_when_job_is_already_gone():
+    launcher = mock.MagicMock()
+    launcher._api_client = mock.MagicMock()
+    launcher._request_timeout = 10
+    launched_container = kubernetes_launchers.LaunchedKubernetesJob(
+        job_name="tangle-ce-execution-123",
+        namespace="default",
+        output_uris={},
+        log_uri="file:///tmp/logs/execution-123",
+        debug_job=k8s_client_lib.V1Job(),
+        launcher=launcher,
+    )
+
+    with (
+        mock.patch.object(kubernetes_launchers.k8s_client_lib, "CoreV1Api") as core_api,
+        mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "BatchV1Api"
+        ) as batch_api,
+    ):
+        batch_api.return_value.delete_namespaced_job.side_effect = (
+            k8s_client_lib.exceptions.ApiException(status=404)
+        )
+        launched_container.terminate()
+
+    core_api.return_value.delete_namespaced_service.assert_called_once_with(
+        name="tangle-ce-execution-123",
+        namespace="default",
+        _request_timeout=10,
+    )
+
+
+def test_kubernetes_job_launcher_deletes_service_when_job_creation_fails():
+    api_client = mock.MagicMock()
+    fake_barrier_token = "fake-barrier-token"
+
+    with (
+        mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "VersionApi"
+        ) as version_api,
+        mock.patch.object(kubernetes_launchers.k8s_client_lib, "CoreV1Api") as core_api,
+        mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "BatchV1Api"
+        ) as batch_api,
+        mock.patch.object(
+            kubernetes_launchers.secrets,
+            "token_hex",
+            return_value=fake_barrier_token,
+        ),
+    ):
+        version_api.return_value.get_code.return_value = object()
+        batch_api.return_value.create_namespaced_job.side_effect = RuntimeError(
+            "job create failed"
+        )
+        launcher = kubernetes_launchers.Local_Kubernetes_UsingHostPathStorage_KubernetesJobLauncher(
+            api_client=api_client,
+            namespace="default",
+        )
+
+        with pytest.raises(kubernetes_launchers.interfaces.LauncherError) as exc_info:
+            launcher.launch_container_task(
+                component_spec=component_structures.ComponentSpec(
+                    implementation=component_structures.ContainerImplementation(
+                        container=component_structures.ContainerSpec(
+                            image="python:3.12"
+                        )
+                    )
+                ),
+                input_arguments={},
+                output_uris={},
+                log_uri="file:///tmp/logs/execution-123",
+                annotations={
+                    common_annotations.CONTAINER_EXECUTION_ID_ANNOTATION_KEY: "execution-123",
+                    kubernetes_launchers.MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY: "2",
+                },
+            )
+
+    assert fake_barrier_token not in str(exc_info.value)
+    assert "[REDACTED]" in str(exc_info.value)
+    core_api.return_value.delete_namespaced_service.assert_called_once_with(
+        name="tangle-ce-execution-123",
+        namespace="default",
+        _request_timeout=10,
+    )

--- a/tests/test_multi_node_runtime.py
+++ b/tests/test_multi_node_runtime.py
@@ -1,0 +1,216 @@
+import socket
+import struct
+import threading
+import time
+
+import pytest
+
+from cloud_pipelines_backend.runtime import multi_node
+
+
+def _unused_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _connect_and_reset(port: int) -> None:
+    deadline = time.monotonic() + 1
+    while True:
+        try:
+            connection = socket.create_connection(("127.0.0.1", port), timeout=0.05)
+            connection.setsockopt(
+                socket.SOL_SOCKET,
+                socket.SO_LINGER,
+                struct.pack("ii", 1, 0),
+            )
+            connection.close()
+            return
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.01)
+
+
+def _config_for_node(
+    node_index: int, number_of_nodes: int = 3
+) -> multi_node.MultiNodeConfig:
+    return multi_node.MultiNodeConfig(
+        number_of_nodes=number_of_nodes,
+        node_index=node_index,
+        node_0_address="127.0.0.1",
+        all_node_addresses=tuple(
+            f"node-{idx}.example" for idx in range(number_of_nodes)
+        ),
+        barrier_token="test-token",
+    )
+
+
+def test_multi_node_config_from_env_parses_launcher_values():
+    config = multi_node.MultiNodeConfig.from_env(
+        {
+            multi_node.NUMBER_OF_NODES_ENV_VAR_NAME: "3",
+            multi_node.NODE_INDEX_ENV_VAR_NAME: "2",
+            multi_node.NODE_0_ADDRESS_ENV_VAR_NAME: "job-0.service",
+            multi_node.ALL_NODE_ADDRESSES_ENV_VAR_NAME: "job-0.service,job-1.service,job-2.service",
+            multi_node.BARRIER_TOKEN_ENV_VAR_NAME: "token",
+        }
+    )
+
+    assert config.number_of_nodes == 3
+    assert config.node_index == 2
+    assert config.node_0_address == "job-0.service"
+    assert config.all_node_addresses == (
+        "job-0.service",
+        "job-1.service",
+        "job-2.service",
+    )
+    assert config.barrier_token == "token"
+
+
+def test_multi_node_config_defaults_to_single_node():
+    config = multi_node.MultiNodeConfig.from_env({})
+
+    assert config == multi_node.MultiNodeConfig(
+        number_of_nodes=1,
+        node_index=0,
+        node_0_address="localhost",
+        all_node_addresses=("localhost",),
+    )
+    multi_node.barrier(config=config, timeout_seconds=0.01, port=1)
+
+
+def test_multi_node_config_requires_barrier_token_for_multi_node():
+    with pytest.raises(
+        multi_node.MultiNodeConfigurationError,
+        match=multi_node.BARRIER_TOKEN_ENV_VAR_NAME,
+    ):
+        multi_node.MultiNodeConfig(
+            number_of_nodes=2,
+            node_index=1,
+            node_0_address="node-0",
+            all_node_addresses=("node-0", "node-1"),
+        )
+
+
+def test_multi_node_config_rejects_empty_address_entries_from_env():
+    with pytest.raises(
+        multi_node.MultiNodeConfigurationError,
+        match=multi_node.ALL_NODE_ADDRESSES_ENV_VAR_NAME,
+    ):
+        multi_node.MultiNodeConfig.from_env(
+            {
+                multi_node.NUMBER_OF_NODES_ENV_VAR_NAME: "2",
+                multi_node.NODE_INDEX_ENV_VAR_NAME: "0",
+                multi_node.NODE_0_ADDRESS_ENV_VAR_NAME: "node-0",
+                multi_node.ALL_NODE_ADDRESSES_ENV_VAR_NAME: "node-0,",
+                multi_node.BARRIER_TOKEN_ENV_VAR_NAME: "token",
+            }
+        )
+
+
+def test_barrier_releases_all_nodes_after_every_node_arrives():
+    port = _unused_tcp_port()
+    completed_node_indexes: list[int] = []
+    errors: list[BaseException] = []
+
+    def wait_at_barrier(node_index: int) -> None:
+        try:
+            multi_node.barrier(
+                "finished",
+                config=_config_for_node(node_index),
+                port=port,
+                timeout_seconds=3,
+                connect_retry_interval_seconds=0.01,
+            )
+            completed_node_indexes.append(node_index)
+        except BaseException as ex:
+            errors.append(ex)
+
+    threads = [
+        threading.Thread(target=wait_at_barrier, args=(node_index,))
+        for node_index in [1, 2]
+    ]
+    for thread in threads:
+        thread.start()
+    time.sleep(0.05)
+
+    coordinator_thread = threading.Thread(target=wait_at_barrier, args=(0,))
+    coordinator_thread.start()
+    threads.append(coordinator_thread)
+
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert sorted(completed_node_indexes) == [0, 1, 2]
+
+
+def test_barrier_ignores_reset_connection_before_valid_worker_arrives():
+    port = _unused_tcp_port()
+    completed_node_indexes: list[int] = []
+    errors: list[BaseException] = []
+
+    def wait_at_barrier(node_index: int) -> None:
+        try:
+            multi_node.barrier(
+                "finished",
+                config=_config_for_node(node_index, number_of_nodes=2),
+                port=port,
+                timeout_seconds=2,
+                connect_retry_interval_seconds=0.01,
+            )
+            completed_node_indexes.append(node_index)
+        except BaseException as ex:
+            errors.append(ex)
+
+    coordinator_thread = threading.Thread(target=wait_at_barrier, args=(0,))
+    coordinator_thread.start()
+    _connect_and_reset(port)
+
+    worker_thread = threading.Thread(target=wait_at_barrier, args=(1,))
+    worker_thread.start()
+
+    coordinator_thread.join(timeout=5)
+    worker_thread.join(timeout=5)
+
+    assert not coordinator_thread.is_alive()
+    assert not worker_thread.is_alive()
+    assert errors == []
+    assert sorted(completed_node_indexes) == [0, 1]
+
+
+def test_barrier_wraps_coordinator_bind_failure():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("", 0))
+        listener.listen()
+        port = int(listener.getsockname()[1])
+
+        with pytest.raises(
+            multi_node.MultiNodeBarrierError,
+            match="Failed to listen",
+        ):
+            multi_node.barrier(
+                "finished",
+                config=_config_for_node(0, number_of_nodes=2),
+                port=port,
+                timeout_seconds=0.1,
+                connect_retry_interval_seconds=0.01,
+            )
+
+
+def test_barrier_times_out_with_missing_node_indexes():
+    port = _unused_tcp_port()
+
+    with pytest.raises(
+        multi_node.MultiNodeBarrierTimeoutError,
+        match=r"missing node indexes: \[1\]",
+    ):
+        multi_node.barrier(
+            "finished",
+            config=_config_for_node(0, number_of_nodes=2),
+            port=port,
+            timeout_seconds=0.1,
+            connect_retry_interval_seconds=0.01,
+        )

--- a/tests/test_orchestrator_cleanup.py
+++ b/tests/test_orchestrator_cleanup.py
@@ -1,0 +1,80 @@
+from typing import Callable
+from unittest import mock
+
+from sqlalchemy import orm
+
+from cloud_pipelines_backend import api_server_sql
+from cloud_pipelines_backend import component_structures
+from cloud_pipelines_backend import database_ops
+from cloud_pipelines_backend import orchestrator_sql
+from cloud_pipelines_backend.launchers import interfaces as launcher_interfaces
+
+
+def _initialize_db_and_get_session_factory() -> Callable[[], orm.Session]:
+    db_engine = database_ops.create_db_engine_and_migrate_db(database_uri="sqlite://")
+    return lambda: orm.Session(bind=db_engine)
+
+
+def test_orchestrator_cleans_up_terminal_launched_container():
+    session_factory = _initialize_db_and_get_session_factory()
+    container_task = component_structures.TaskSpec(
+        component_ref=component_structures.ComponentReference(
+            spec=component_structures.ComponentSpec(
+                implementation=component_structures.ContainerImplementation(
+                    container=component_structures.ContainerSpec(image="python:3.12")
+                )
+            )
+        ),
+        arguments={},
+    )
+    root_task = component_structures.TaskSpec(
+        component_ref=component_structures.ComponentReference(
+            spec=component_structures.ComponentSpec(
+                implementation=component_structures.GraphImplementation(
+                    graph=component_structures.GraphSpec(tasks={"task": container_task})
+                )
+            )
+        ),
+        arguments={},
+    )
+    api_server_sql.PipelineRunsApiService_Sql().create(
+        session=session_factory(),
+        root_task=root_task,
+        created_by="user",
+    )
+
+    launched_container = mock.MagicMock()
+    launched_container.status = launcher_interfaces.ContainerStatus.PENDING
+    launched_container.to_dict.return_value = {"launcher": "pending"}
+
+    reloaded_container = mock.MagicMock()
+    reloaded_container.status = launcher_interfaces.ContainerStatus.SUCCEEDED
+    reloaded_container.to_dict.return_value = {"launcher": "succeeded"}
+    reloaded_container.exit_code = 0
+    reloaded_container.started_at = None
+    reloaded_container.ended_at = None
+
+    launcher = mock.MagicMock()
+    launcher.launch_container_task.return_value = launched_container
+    launcher.deserialize_launched_container_from_dict.return_value = launched_container
+    launcher.get_refreshed_launched_container_from_dict.return_value = (
+        reloaded_container
+    )
+
+    orchestrator = orchestrator_sql.OrchestratorService_Sql(
+        session_factory=session_factory,
+        launcher=launcher,
+        storage_provider=mock.MagicMock(),
+        data_root_uri="file:///tmp/artifacts",
+        logs_root_uri="file:///tmp/logs",
+    )
+
+    with session_factory() as session:
+        assert orchestrator.internal_process_queued_executions_queue(session=session)
+    with session_factory() as session:
+        assert orchestrator.internal_process_running_executions_queue(session=session)
+
+    reloaded_container.cleanup.assert_called_once_with()
+    assert reloaded_container.method_calls.index(
+        mock.call.cleanup()
+    ) < reloaded_container.method_calls.index(mock.call.upload_log())


### PR DESCRIPTION
Adds a reusable multi-node barrier helper for Kubernetes-backed Tangle tasks.

### What changed

- Adds `cloud_pipelines_backend.runtime.multi_node.barrier(...)` for Python components that need all nodes in a multi-node task to rendezvous before one node continues or exits.
- Injects launcher-controlled multi-node runtime env vars into Indexed Kubernetes Jobs, including node count, node index, node addresses, barrier port, and a per-task barrier token.
- Exposes the barrier port through the task headless Service and enables not-ready pod DNS publication so workers can retry while node 0 starts.
- Redacts sensitive env values from serialized Kubernetes debug data and job-creation error messages.
- Cleans up the task headless Service on job creation failure, explicit termination, and normal terminal job processing.

### Notes

This is intentionally a small Python runtime helper plus Kubernetes launcher wiring. It does not try to be an authentication boundary; the token is only meant to prevent accidental cross-talk between tasks sharing the same network namespace.

Draft because the API shape and runtime packaging constraints should be checked by Tangle maintainers before treating this as final.

### Testing

- `uv run black --check cloud_pipelines_backend/runtime/multi_node.py cloud_pipelines_backend/runtime/__init__.py cloud_pipelines_backend/launchers/interfaces.py cloud_pipelines_backend/launchers/kubernetes_launchers.py cloud_pipelines_backend/orchestrator_sql.py tests/test_multi_node_runtime.py tests/test_kubernetes_multi_node.py tests/test_orchestrator_cleanup.py` → passed. Black printed the existing Python 3.12 vs 3.14 safety-check warning.
- `git diff --cached --check` → passed.
- `PYTHONPATH=. uv run pytest` → 376 passed, 11 warnings. Warnings were existing SQLAlchemy `Row.tuple()` deprecation warnings; the test run also printed local OpenTelemetry exporter-unavailable messages after pytest completed.

Not yet tested against a real multi-node Kubernetes task; that should be part of follow-up validation for the draft API.
