### PR TITLE
chore: CI - Explicitly limit the GitHub test workflow permissions

### DIFF
--- a/.github/workflows/run_tests_on_push.yaml
+++ b/.github/workflows/run_tests_on_push.yaml
@@ -19,6 +19,9 @@ on:
       - stable
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   uv-pytest:
     name: python


### PR DESCRIPTION
Fixes https://github.com/TangleML/tangle/security/code-scanning/1