### PR TITLE
fix: 500 error when published component size is too large

### DIFF
--- a/cloud_pipelines_backend/component_library_api_server.py
+++ b/cloud_pipelines_backend/component_library_api_server.py
@@ -20,14 +20,19 @@ def calculate_digest_for_component_text(text: str) -> str:
     return digest
 
 
-MAX_COMPONENT_SIZE = 300_000
+# Baseline: MySQL TEXT column maximum (65,535 bytes).
+MAX_COMPONENT_SIZE_BYTES = 65_535
 
 
 def load_component_spec_from_text_and_validate(
     text: str,
 ) -> component_structures.ComponentSpec:
-    if len(text) > MAX_COMPONENT_SIZE:
-        raise ValueError(f"Component size {len(text)} > {MAX_COMPONENT_SIZE=}.")
+    text_bytes = len(text.encode("utf-8"))
+    if text_bytes > MAX_COMPONENT_SIZE_BYTES:
+        raise errors.ApiValidationError(
+            f"Component text is too large: {text_bytes} bytes"
+            f" (maximum allowed: {MAX_COMPONENT_SIZE_BYTES} bytes)."
+        )
     component_dict = yaml.safe_load(text)
     return load_component_spec_from_dict_and_validate(component_dict)
 

--- a/tests/test_component_library_api_server.py
+++ b/tests/test_component_library_api_server.py
@@ -1,4 +1,5 @@
 from sqlalchemy import orm
+import pydantic
 import yaml
 import pytest
 
@@ -312,6 +313,34 @@ def test_component_library_service():
             session=session, user_name=user_name
         ).component_library_ids
         assert pins_11b == pins_11
+
+
+def test_component_text_at_byte_limit_is_accepted():
+    """Component text of exactly MAX_COMPONENT_SIZE_BYTES bytes does not raise ApiValidationError."""
+    text = "a" * components_api.MAX_COMPONENT_SIZE_BYTES
+    assert len(text.encode("utf-8")) == components_api.MAX_COMPONENT_SIZE_BYTES
+    # Only assert that the size check does not reject the input; downstream
+    # yaml/pydantic parsing errors are expected because "a" * N is not a
+    # valid component spec.
+    try:
+        components_api.load_component_spec_from_text_and_validate(text)
+    except errors.ApiValidationError:
+        pytest.fail(
+            "ApiValidationError should not be raised for text at the byte limit"
+        )
+    except (yaml.YAMLError, pydantic.ValidationError):
+        pass  # Expected: synthetic text is not valid YAML / ComponentSpec
+    except Exception as exc:
+        pytest.fail(f"Unexpected exception raised: {type(exc).__name__}: {exc}")
+
+
+def test_component_text_one_byte_over_limit_raises_api_validation_error():
+    """Component text of MAX_COMPONENT_SIZE_BYTES + 1 bytes raises ApiValidationError."""
+    text = "a" * (components_api.MAX_COMPONENT_SIZE_BYTES + 1)
+    assert len(text.encode("utf-8")) == components_api.MAX_COMPONENT_SIZE_BYTES + 1
+    with pytest.raises(errors.ApiValidationError) as exc_info:
+        components_api.load_component_spec_from_text_and_validate(text)
+    assert str(components_api.MAX_COMPONENT_SIZE_BYTES) in str(exc_info.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fix: validate component text size before MySQL insert

### Problem

`POST /api/published_components/` was crashing with an unhandled `pymysql.err.DataError`
when component text exceeded the MySQL `TEXT` column limit (65,535 bytes):

```
(1406, "Data too long for column 'text' at row 1")
```

The existing `MAX_COMPONENT_SIZE = 300_000` check was in characters, not bytes, and set
far above the actual column capacity — so components between ~65 KB and 300 KB passed
validation and hit the database, which rejected them with a 500.

### Solution

Replace the character-count check with a byte-length check against the real column limit,
and raise `ApiValidationError` (→ HTTP 422) instead of letting the DB error propagate.

**Byte limit**

PostgreSQL and SQLite map `Text()` to unlimited storage, so this limit is based on MySQL.

```python
# Baseline: MySQL TEXT column maximum (65,535 bytes).
# If the column type is ever widened (e.g. to MEDIUMTEXT), update this constant.
MAX_COMPONENT_SIZE_BYTES = 65_535
```

**UTF-8 encoding**

```python
# PyMySQL always encodes Python str to UTF-8 on the wire, so UTF-8 byte length
# is exactly what MySQL receives and measures against the column's byte limit.
text_bytes = len(text.encode("utf-8"))
```

### Changes

- `cloud_pipelines_backend/component_library_api_server.py` — replace `MAX_COMPONENT_SIZE` (character count) with `MAX_COMPONENT_SIZE_BYTES = 65_535` (byte count); raise `errors.ApiValidationError` instead of `ValueError`
- `tests/test_component_library_api_server.py` — add boundary tests for exactly 65,535 bytes (accepted) and 65,536 bytes (rejected with 422)