### PR TITLE
Enrich error/success status spans with failure context

### DIFF
--- a/cloud_pipelines_backend/instrumentation/execution_tracing.py
+++ b/cloud_pipelines_backend/instrumentation/execution_tracing.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 
 from opentelemetry import trace
+from opentelemetry.trace import StatusCode
 
 from .. import backend_types_sql as bts
 
@@ -19,6 +20,39 @@ _tracer = trace.get_tracer("tangle.orchestrator")
 
 _HISTORY_KEY = bts.EXECUTION_NODE_EXTRA_DATA_STATUS_HISTORY_KEY
 _TERMINAL_STATUSES = frozenset(s.value for s in bts.CONTAINER_STATUSES_ENDED)
+_ERROR_TERMINAL_STATUSES = frozenset({
+    bts.ContainerExecutionStatus.FAILED,
+    bts.ContainerExecutionStatus.SYSTEM_ERROR,
+})
+
+
+def _error_attrs(*, execution: bts.ExecutionNode, status: str) -> dict[str, object]:
+    """Extra attributes for terminal error/success status spans."""
+    extra = execution.extra_data or {}
+    attrs: dict[str, object] = {}
+
+    def _set_exit_code() -> None:
+        if (ce := execution.container_execution) and ce.exit_code is not None:
+            attrs["execution.exit_code"] = ce.exit_code
+
+    if status == bts.ContainerExecutionStatus.FAILED:
+        msg = extra.get(bts.EXECUTION_NODE_EXTRA_DATA_ORCHESTRATION_ERROR_MESSAGE_KEY)
+        if msg is not None:
+            attrs["exception.message"] = msg
+        _set_exit_code()
+    elif status == bts.ContainerExecutionStatus.SYSTEM_ERROR:
+        msg = extra.get(
+            bts.EXECUTION_NODE_EXTRA_DATA_SYSTEM_ERROR_EXCEPTION_MESSAGE_KEY
+        )
+        if msg is not None:
+            attrs["exception.message"] = msg
+        tb = extra.get(bts.EXECUTION_NODE_EXTRA_DATA_SYSTEM_ERROR_EXCEPTION_FULL_KEY)
+        if tb is not None:
+            attrs["exception.stacktrace"] = tb
+    elif status == bts.ContainerExecutionStatus.SUCCEEDED:
+        _set_exit_code()
+
+    return attrs
 
 
 def _ns(*, dt: datetime.datetime) -> int:
@@ -58,6 +92,7 @@ def try_emit_execution_trace(*, execution: bts.ExecutionNode) -> None:
             attrs: dict[str, object] = {
                 "execution.id": execution.id,
                 "execution.status": entry["status"],
+                **_error_attrs(execution=execution, status=entry["status"]),
             }
             _tracer.start_span(
                 f"execution.status {entry['status']}",
@@ -66,6 +101,8 @@ def try_emit_execution_trace(*, execution: bts.ExecutionNode) -> None:
                 start_time=_ns(dt=t_start),
             ).end(end_time=_ns(dt=t_end))
 
+        if history[-1]["status"] in _ERROR_TERMINAL_STATUSES:
+            root.set_status(status=StatusCode.ERROR)
         root.end(end_time=_ns(dt=last_time))
     except Exception:
         _logger.exception(f"Failed to emit execution trace for {execution.id!r}")

--- a/tests/instrumentation/test_execution_tracing.py
+++ b/tests/instrumentation/test_execution_tracing.py
@@ -144,3 +144,69 @@ class TestTryEmitExecutionTrace:
             "execution.status QUEUED",
             "execution.status SUCCEEDED",
         }
+
+
+class TestErrorDataAttrs:
+    def test_failed_span_carries_orchestration_error_message(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(
+            statuses=["QUEUED", "RUNNING", "FAILED"],
+            extra={
+                bts.EXECUTION_NODE_EXTRA_DATA_ORCHESTRATION_ERROR_MESSAGE_KEY: "missing outputs"
+            },
+        )
+        execution_tracing.try_emit_execution_trace(execution=execution)
+
+        failed_span = next(
+            s
+            for s in span_exporter.get_finished_spans()
+            if s.attributes.get("execution.status") == "FAILED"
+        )
+        assert failed_span.attributes["exception.message"] == "missing outputs"
+
+    def test_system_error_span_carries_exception_message_and_stacktrace(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(
+            statuses=["QUEUED", "SYSTEM_ERROR"],
+            extra={
+                bts.EXECUTION_NODE_EXTRA_DATA_SYSTEM_ERROR_EXCEPTION_MESSAGE_KEY: "RuntimeError",
+                bts.EXECUTION_NODE_EXTRA_DATA_SYSTEM_ERROR_EXCEPTION_FULL_KEY: "Traceback...",
+            },
+        )
+        execution_tracing.try_emit_execution_trace(execution=execution)
+
+        err_span = next(
+            s
+            for s in span_exporter.get_finished_spans()
+            if s.attributes.get("execution.status") == "SYSTEM_ERROR"
+        )
+        assert err_span.attributes["exception.message"] == "RuntimeError"
+        assert err_span.attributes["exception.stacktrace"] == "Traceback..."
+
+    def test_root_span_marked_error_on_failed(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        from opentelemetry.trace import StatusCode
+
+        execution = _make_execution(statuses=["QUEUED", "FAILED"])
+        execution_tracing.try_emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert root.status.status_code == StatusCode.ERROR
+
+    def test_root_span_not_marked_error_on_succeeded(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        from opentelemetry.trace import StatusCode
+
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution_tracing.try_emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert root.status.status_code != StatusCode.ERROR


### PR DESCRIPTION
## Enrich execution trace spans with error details and root span status

**FAILED span:** Attaches `error.message` from `orchestration_error_message` in `extra_data` and `execution.exit_code` from the associated `ContainerExecution` when available.

**SYSTEM_ERROR span:** Attaches `error.message` from the system error exception message and `exception.stacktrace` from the full exception traceback stored in `extra_data`.

**SUCCEEDED span:** Attaches `execution.exit_code` from the associated `ContainerExecution` when available.

**Root span:** Calls `set_status(ERROR)` when the terminal status is `FAILED` or `SYSTEM_ERROR`, leaving the root span unmarked for successful executions.

## Screenshots

![Screenshot 2026-05-22 at 8.14.49 PM.png](https://app.graphite.com/user-attachments/assets/d82aa67c-3db5-487b-b8ab-0a654ebd0456.png)