### PR TITLE
Add launcher type and cluster URL to root execution span

### DIFF
--- a/cloud_pipelines_backend/instrumentation/execution_tracing.py
+++ b/cloud_pipelines_backend/instrumentation/execution_tracing.py
@@ -18,12 +18,16 @@ from .. import backend_types_sql as bts
 _logger = logging.getLogger(__name__)
 _tracer = trace.get_tracer("tangle.orchestrator")
 
+_CLOUD_PROVIDER_ANNOTATION_KEY = "cloud-pipelines.net/orchestration/cloud_provider"
+
 _HISTORY_KEY = bts.EXECUTION_NODE_EXTRA_DATA_STATUS_HISTORY_KEY
 _TERMINAL_STATUSES = frozenset(s.value for s in bts.CONTAINER_STATUSES_ENDED)
-_ERROR_TERMINAL_STATUSES = frozenset({
-    bts.ContainerExecutionStatus.FAILED,
-    bts.ContainerExecutionStatus.SYSTEM_ERROR,
-})
+_ERROR_TERMINAL_STATUSES = frozenset(
+    {
+        bts.ContainerExecutionStatus.FAILED,
+        bts.ContainerExecutionStatus.SYSTEM_ERROR,
+    }
+)
 
 
 def _error_attrs(*, execution: bts.ExecutionNode, status: str) -> dict[str, object]:
@@ -81,6 +85,46 @@ def _launcher_pod_attrs(
     return attrs
 
 
+def _launcher_type_attrs(*, execution: bts.ExecutionNode) -> dict[str, object]:
+    """Launcher type and cluster identity for the root execution span.
+
+    Uses the top-level key of launcher_data as the launcher type — forward-compatible
+    with any launcher implementation.  For k8s-family launchers adds cluster_server
+    so GKE and Nebius clusters (which share the same launcher class in oasis-backend)
+    can be distinguished by URL pattern.
+    """
+    if execution.container_execution_id is None:
+        return {}
+    ce = execution.container_execution
+    if ce is None or not ce.launcher_data:
+        return {}
+    launcher_key = next(iter(ce.launcher_data))
+    attrs: dict[str, object] = {"execution.launcher": launcher_key}
+    inner = ce.launcher_data[launcher_key]
+    if isinstance(inner, dict) and (cluster_url := inner.get("cluster_server")):
+        attrs["k8s.cluster.url"] = cluster_url
+    return attrs
+
+
+def _cloud_provider_attrs(*, execution: bts.ExecutionNode) -> dict[str, object]:
+    """Cloud provider for the root execution span, read from task_spec annotations.
+
+    Returns ``{"execution.cloud_provider": value}`` when the
+    ``cloud-pipelines.net/orchestration/cloud_provider`` annotation is present,
+    otherwise an empty dict.  Callers (e.g. oasis-backend's MultiLauncherContainerLauncher)
+    set this annotation at routing time; tangle launchers with a fixed cloud affinity
+    can set it too.
+    """
+    provider = (
+        (execution.task_spec or {})
+        .get("annotations", {})
+        .get(_CLOUD_PROVIDER_ANNOTATION_KEY)
+    )
+    if provider is None:
+        return {}
+    return {"execution.cloud_provider": provider}
+
+
 def _ns(*, dt: datetime.datetime) -> int:
     """Return *dt* as nanoseconds since the Unix epoch (required by OTel SDK)."""
     if dt.tzinfo is None:
@@ -103,7 +147,11 @@ def emit_execution_trace(*, execution: bts.ExecutionNode) -> None:
 
         root = _tracer.start_span(
             "execution",
-            attributes={"execution.id": execution.id},
+            attributes={
+                "execution.id": execution.id,
+                **_launcher_type_attrs(execution=execution),
+                **_cloud_provider_attrs(execution=execution),
+            },
             start_time=_ns(dt=first_time),
         )
         root_ctx = trace.set_span_in_context(root)

--- a/tests/instrumentation/test_execution_tracing.py
+++ b/tests/instrumentation/test_execution_tracing.py
@@ -277,3 +277,67 @@ class TestLauncherPodAttrs:
 
         for span in span_exporter.get_finished_spans():
             assert "k8s.pod.name" not in (span.attributes or {})
+
+
+class TestLauncherTypeAttrs:
+    def test_root_span_carries_launcher_type_and_cluster_url(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        ce = bts.ContainerExecution(
+            status=bts.ContainerExecutionStatus.SUCCEEDED,
+            launcher_data={
+                "kubernetes": {
+                    "pod_name": "exec-abc-pod",
+                    "namespace": "tangle",
+                    "cluster_server": "https://gke.example.com",
+                }
+            },
+        )
+        execution.container_execution = ce
+        execution.container_execution_id = "ce-test-id"
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert root.attributes["execution.launcher"] == "kubernetes"
+        assert root.attributes["k8s.cluster.url"] == "https://gke.example.com"
+
+    def test_root_span_omits_launcher_without_container_execution(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert "execution.launcher" not in (root.attributes or {})
+
+    def test_root_span_carries_cloud_provider_when_annotation_set(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution.task_spec = {
+            "annotations": {
+                "cloud-pipelines.net/orchestration/cloud_provider": "nebius"
+            }
+        }
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert root.attributes["execution.cloud_provider"] == "nebius"
+
+    def test_root_span_omits_cloud_provider_when_annotation_absent(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert "execution.cloud_provider" not in (root.attributes or {})


### PR DESCRIPTION
## Add `execution.launcher` and `execution.cloud_provider` OTel trace attributes to root execution span

`execution.launcher` is derived from the top-level key of `launcher_data` (e.g. `kubernetes`, `kubernetes_job`, `skypilot`) and distinguishes the launcher mechanism used for a given execution.

`k8s.cluster.url` on the root span allows GKE vs Nebius cluster identification by URL pattern in oasis-backend's multi-cloud setup, populated from `cluster_server` inside the launcher's data block.

`execution.cloud_provider` is read from the `cloud-pipelines.net/orchestration/cloud_provider` task_spec annotation, set at routing time by callers such as `MultiLauncherContainerLauncher`. This enables traces to be searched by cloud provider (e.g. `gke`, `nebius`) without relying on URL pattern matching against cluster hostnames. Launchers with a fixed cloud affinity can also set this annotation directly.

The `CLOUD_PROVIDER_ANNOTATION_KEY` constant is defined in `common_annotations` so it can be shared across launchers and the tracing layer without duplication.

## Screenshots

![Screenshot 2026-05-22 at 8.19.10 PM.png](https://app.graphite.com/user-attachments/assets/05086e4d-4708-4c0b-b376-bec786701bde.png)