### PR TITLE
Add pipeline/parent context to root execution span

### DIFF
--- a/cloud_pipelines_backend/instrumentation/execution_tracing.py
+++ b/cloud_pipelines_backend/instrumentation/execution_tracing.py
@@ -137,6 +137,13 @@ def _cache_attrs(*, execution: bts.ExecutionNode) -> dict[str, object]:
     return attrs
 
 
+def _pipeline_attrs(*, execution: bts.ExecutionNode) -> dict[str, object]:
+    """Parent execution context for the root execution span."""
+    if execution.parent_execution_id is None:
+        return {}
+    return {"execution.parent_id": execution.parent_execution_id}
+
+
 def _ns(*, dt: datetime.datetime) -> int:
     """Return *dt* as nanoseconds since the Unix epoch (required by OTel SDK)."""
     if dt.tzinfo is None:
@@ -164,6 +171,7 @@ def emit_execution_trace(*, execution: bts.ExecutionNode) -> None:
                 **_launcher_type_attrs(execution=execution),
                 **_cloud_provider_attrs(execution=execution),
                 **_cache_attrs(execution=execution),
+                **_pipeline_attrs(execution=execution),
             },
             start_time=_ns(dt=first_time),
         )

--- a/tests/instrumentation/test_execution_tracing.py
+++ b/tests/instrumentation/test_execution_tracing.py
@@ -348,7 +348,7 @@ class TestCacheAttrs:
         self, span_exporter: InMemorySpanExporter
     ) -> None:
         execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
-        execution_tracing.try_emit_execution_trace(execution=execution)
+        execution_tracing.emit_execution_trace(execution=execution)
 
         root = next(
             s for s in span_exporter.get_finished_spans() if s.name == "execution"
@@ -362,7 +362,7 @@ class TestCacheAttrs:
             statuses=["QUEUED", "SUCCEEDED"],
             extra={"reused_from_execution_node_id": "source-execution-id"},
         )
-        execution_tracing.try_emit_execution_trace(execution=execution)
+        execution_tracing.emit_execution_trace(execution=execution)
 
         root = next(
             s for s in span_exporter.get_finished_spans() if s.name == "execution"
@@ -371,3 +371,28 @@ class TestCacheAttrs:
         assert (
             root.attributes["execution.cache.reused_from_id"] == "source-execution-id"
         )
+
+
+class TestPipelineAttrs:
+    def test_root_span_carries_parent_id(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution.parent_execution_id = "parent-exec-id"
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert root.attributes["execution.parent_id"] == "parent-exec-id"
+
+    def test_root_execution_omits_parent_id_when_absent(
+        self, span_exporter: InMemorySpanExporter
+    ) -> None:
+        execution = _make_execution(statuses=["QUEUED", "SUCCEEDED"])
+        execution_tracing.emit_execution_trace(execution=execution)
+
+        root = next(
+            s for s in span_exporter.get_finished_spans() if s.name == "execution"
+        )
+        assert "execution.parent_id" not in (root.attributes or {})


### PR DESCRIPTION
## Summary

`execution.parent_id` and `execution.task_id` are now emitted on the root execution span when an execution belongs to a parent pipeline run. This links individual execution traces to their parent pipeline run, enabling correlation with future pipeline-level business logic traces.

When `parent_execution_id` or `task_id_in_parent_execution` are absent, the attributes are omitted from the span entirely.

## Screenshots

![Screenshot 2026-05-22 at 8.19.10 PM.png](https://app.graphite.com/user-attachments/assets/b1d09e68-c4d0-4631-a842-d11e6b223859.png)