### PR TITLE
kubernetes: suppress tqdm progress bars in all container pods

### DIFF
--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -69,6 +69,16 @@ _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY = "system/multi_node/all_node_ad
 # Environment variables for multi-node execution.
 _MULTI_NODE_NODE_INDEX_ENV_VAR_NAME = "_TANGLE_MULTI_NODE_NODE_INDEX"
 
+# Environment variables injected into every container to suppress tqdm progress
+# bar output. High-volume block-glyph writes (3-byte UTF-8: █▉▊▋▌▍▎▏) from
+# concurrent worker processes interleave at the OS level, producing torn
+# multi-byte sequences in the pod log stream that cause UnicodeDecodeError.
+# Components may override these by setting the same keys in their own env.
+_TQDM_SUPPRESS_ENV_VARS: dict[str, str] = {
+    "TQDM_DISABLE": "1",
+    "HF_DATASETS_DISABLE_PROGRESS_BARS": "1",
+}
+
 
 _T = typing.TypeVar("_T")
 
@@ -352,6 +362,10 @@ class _KubernetesContainerLauncherBase:
             k8s_client_lib.V1EnvVar(name=name, value=value)
             for name, value in (container_spec.env or {}).items()
         ]
+        user_env_names = {env.name for env in container_env}
+        for name, value in _TQDM_SUPPRESS_ENV_VARS.items():
+            if name not in user_env_names:
+                container_env.append(k8s_client_lib.V1EnvVar(name=name, value=value))
         main_container_spec = k8s_client_lib.V1Container(
             name=_MAIN_CONTAINER_NAME,
             image=container_spec.image,


### PR DESCRIPTION
Injects `TQDM_DISABLE=1` and `HF_DATASETS_DISABLE_PROGRESS_BARS=1` into every Kubernetes container environment at the launcher level. Components may override by setting the same keys in their own `env` — those values take precedence.

## Why

HF datasets `map` with `num_proc>1` spawns child processes that each write tqdm block-glyph progress bars (`█▉▊▋▌▍▎▏`, 3-byte UTF-8: `E2 96 8x`) to a shared inherited stderr fd. The OS does not guarantee atomic writes across processes for sequences longer than `PIPE_BUF`, so bytes from concurrent workers interleave mid-glyph. This produces torn multi-byte sequences in the pod log stream which cause `UnicodeDecodeError` in the Kubernetes client's strict `.decode('utf8')`, marking otherwise-healthy training runs as `SYSTEM_ERROR`.

With these env vars set, the tokenization and packing phases emit no non-ASCII bytes — the log stream is pure ASCII and the torn-byte condition cannot occur regardless of `num_proc`.

## Side effects

- Log sizes for heavy tokenization jobs drop significantly. The ~6 MB blobs observed in incident runs (wall-to-wall tqdm bars) shrink to tens of KB of actual training output.
- Tokenization/packing progress is no longer visible in logs. The HF datasets step count and throughput are still logged at completion; only the animated progress bar is suppressed.

## Relationship to #277

This PR and #277 are independent solutions to the same root cause, kept separate for comparison. #277 fixes the Kubernetes client decode layer defensively; this PR eliminates the primary source of non-ASCII bytes. Either alone is an improvement.