### PR TITLE
kubernetes: surface log-unavailable reason and observability link in placeholder

### DIFF
--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -69,6 +69,54 @@ _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY = "system/multi_node/all_node_ad
 # Environment variables for multi-node execution.
 _MULTI_NODE_NODE_INDEX_ENV_VAR_NAME = "_TANGLE_MULTI_NODE_NODE_INDEX"
 
+# Optional URL template for linking to pod logs in an external observability
+# platform when log acquisition fails. Set via TANGLE_LOG_SEARCH_URL_TEMPLATE.
+# Three placeholders are substituted at runtime:
+#   {pod_name}        — the Kubernetes pod name
+#   {start_iso8601_ms} — ISO 8601 UTC ms timestamp, started_at minus 5 min padding
+#                        (e.g. "2026-06-17T20:24:11.000Z"), or 24 h before now as fallback
+#   {end_iso8601_ms}   — ISO 8601 UTC ms timestamp, ended_at plus 5 min padding,
+#                        or now when the pod is still running / end time is unavailable
+# Example for Observe: see oasis-backend deployment config.
+_LOG_SEARCH_URL_TEMPLATE: str | None = os.environ.get("TANGLE_LOG_SEARCH_URL_TEMPLATE")
+
+_LOG_SEARCH_URL_TS_PADDING = datetime.timedelta(minutes=5)
+
+
+def _to_iso8601_ms(dt: datetime.datetime) -> str:
+    """Format a datetime as an ISO 8601 UTC string with millisecond precision."""
+    utc = dt.astimezone(datetime.timezone.utc)
+    return utc.strftime("%Y-%m-%dT%H:%M:%S.") + f"{utc.microsecond // 1000:03d}Z"
+
+
+def _format_log_unavailable_message(
+    pod_name: str,
+    namespace: str,
+    started_at: "datetime.datetime | None",
+    ended_at: "datetime.datetime | None",
+) -> str:
+    """Return a placeholder log string when the Kubernetes API cannot be read."""
+    msg = (
+        f"[Log unavailable: Kubernetes API returned a malformed response. "
+        f"Pod: {pod_name}, Namespace: {namespace}."
+    )
+    if _LOG_SEARCH_URL_TEMPLATE:
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        from_dt = (
+            (started_at - _LOG_SEARCH_URL_TS_PADDING)
+            if started_at
+            else (now - datetime.timedelta(hours=24))
+        )
+        to_dt = (ended_at + _LOG_SEARCH_URL_TS_PADDING) if ended_at else now
+        url = (
+            _LOG_SEARCH_URL_TEMPLATE.replace("{pod_name}", pod_name)
+            .replace("{start_iso8601_ms}", _to_iso8601_ms(from_dt))
+            .replace("{end_iso8601_ms}", _to_iso8601_ms(to_dt))
+        )
+        msg += f" Search: {url}"
+    msg += "]\n"
+    return msg
+
 
 _T = typing.TypeVar("_T")
 
@@ -944,7 +992,9 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
                 self._pod_name,
                 exc_info=True,
             )
-            return ""
+            return _format_log_unavailable_message(
+                self._pod_name, self._namespace, self.started_at, self.ended_at
+            )
 
     def upload_log(self):
         launcher = self._get_launcher()
@@ -1528,7 +1578,9 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
                 pod_name,
                 exc_info=True,
             )
-            return None
+            return _format_log_unavailable_message(
+                pod_name, self._namespace, self.started_at, self.ended_at
+            )
 
     def _get_all_logs(self) -> dict[str, str]:
         logs = {}


### PR DESCRIPTION
Stacked on #279.

When log acquisition fails (broken UTF-8, truncated response, broken JSON from the Kubernetes API), instead of returning an empty string the launcher stores a human-readable placeholder containing the pod name, namespace, and — when `TANGLE_LOG_SEARCH_URL_TEMPLATE` is configured — a direct link to the pod's logs in the deployment's observability platform.

The placeholder is stored in GCS via `upload_log` and returned verbatim by the log-read API, so it surfaces wherever logs are displayed without any frontend or schema changes.

## Time range — absolute ISO 8601 timestamps

The link uses a fixed, absolute time window so it stays accurate regardless of when the link is clicked (a relative `now-Xm` would drift and become useless after retention).

Both `started_at` and `ended_at` are already in memory — no DB queries:

| Launcher class | `started_at` source | `ended_at` source |
|---|---|---|
| `LaunchedKubernetesContainer` | `self._debug_pod.status` container state | `self._debug_pod.status` terminated state |
| `LaunchedKubernetesJob` | `self._debug_job.status.start_time` | job completion condition `last_transition_time` |

The window is `started_at − 5 min` → `ended_at + 5 min`, matching the padding used by the tangle-ui overlay schema. Falls back to `now − 24 h` → `now` when timestamps are unavailable (pod still pending, or status not yet populated).

## OSS design

`TANGLE_LOG_SEARCH_URL_TEMPLATE` is a generic env var with three `str.replace` placeholders:

| Placeholder | Substituted with |
|---|---|
| `{pod_name}` | Kubernetes pod name |
| `{start_iso8601_ms}` | `started_at − 5 min` as `2026-06-17T20:24:11.000Z`, or `now − 24 h` as fallback |
| `{end_iso8601_ms}` | `ended_at + 5 min` as `2026-06-17T22:36:44.000Z`, or `now` as fallback |

No observability-platform-specific naming or logic in the OSS code. Deployments that set the env var get a direct link; deployments that omit it get the pod name and namespace only.

## Example output

**Without `TANGLE_LOG_SEARCH_URL_TEMPLATE` set** (any OSS deployment):
```
[Log unavailable: Kubernetes API returned a malformed response. Pod: task-019ed73257f0c30a068a-0-xk9pq, Namespace: ml-infra-nebius.]
```

**With `TANGLE_LOG_SEARCH_URL_TEMPLATE` set** (e.g. Shopify's Observe deployment):
```
[Log unavailable: Kubernetes API returned a malformed response. Pod: task-019ed73257f0c30a068a-0-xk9pq, Namespace: ml-infra-nebius. Search: https://observe.shopify.io/a/observe/investigate/query?mls=...&q=...kube_pod+contains+task-019ed73257f0c30a068a-0-xk9pq...&r={"from":"2026-06-17T20:24:11.000Z","to":"2026-06-17T22:36:44.000Z"}&category=logging]
```

The link opens Observe pre-filtered to that pod, on a 2h 17m window (the job's actual runtime ± 5 min padding).

## Deployment config

The Observe URL template is set for production and staging in `infrastructure/applications/oasis-backend/{production,staging}/app.yaml` — see Shopify/infrastructure#52749.