### PR TITLE
Event-based PVC reaper (watch-only)

### DIFF
--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -57,6 +57,16 @@ SECURITY_CONTEXT_CAPABILITY_IPC_LOCK_ANNOTATION_KEY = (
 )
 
 
+# Kubernetes labels (not annotations) applied to auto-provisioned PVCs so that
+# KubernetesPVCReaper can select them and delete them when their owning Job is
+# deleted. Labels are used (rather than annotations) so they are usable in a
+# Kubernetes label selector. Label keys allow a single "/" (prefix/name), so
+# these use the flat form rather than the multi-segment annotation keys above.
+PVC_MANAGED_LABEL_KEY = "tangleml.com/managed-pvc"
+PVC_MANAGED_LABEL_VALUE = "true"
+PVC_OWNER_JOB_NAME_LABEL_KEY = "tangleml.com/owner-job-name"
+
+
 # Multi-node constants
 _MULTI_NODE_MAX_NUMBER_OF_NODES = 16
 
@@ -143,6 +153,46 @@ def _create_volume_and_volume_mount_google_cloud_storage(
             read_only=read_only,
             sub_path=sub_path,
         ),
+    )
+
+
+def create_managed_pvc(
+    *,
+    core_api_client: k8s_client_lib.CoreV1Api,
+    namespace: str,
+    pvc_name: str,
+    owner_job_name: str,
+    storage_class_name: str,
+    storage_size: str,
+    access_modes: list[str] | None = None,
+    request_timeout: int | tuple[int, int] = 10,
+) -> k8s_client_lib.V1PersistentVolumeClaim:
+    """Create a PVC labeled for event-based reaping by KubernetesPVCReaper.
+
+    The PVC is labeled so that when the Job named ``owner_job_name`` is deleted,
+    the reaper deletes this PVC. ``storage_class_name`` is caller-supplied because
+    the appropriate storage class is environment-specific.
+    """
+    pvc = k8s_client_lib.V1PersistentVolumeClaim(
+        metadata=k8s_client_lib.V1ObjectMeta(
+            name=pvc_name,
+            labels={
+                PVC_MANAGED_LABEL_KEY: PVC_MANAGED_LABEL_VALUE,
+                PVC_OWNER_JOB_NAME_LABEL_KEY: owner_job_name,
+            },
+        ),
+        spec=k8s_client_lib.V1PersistentVolumeClaimSpec(
+            storage_class_name=storage_class_name,
+            access_modes=access_modes or ["ReadWriteMany"],
+            resources=k8s_client_lib.V1VolumeResourceRequirements(
+                requests={"storage": storage_size},
+            ),
+        ),
+    )
+    return core_api_client.create_namespaced_persistent_volume_claim(
+        namespace=namespace,
+        body=pvc,
+        _request_timeout=request_timeout,
     )
 
 

--- a/cloud_pipelines_backend/launchers/kubernetes_pvc_reaper.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_pvc_reaper.py
@@ -1,0 +1,164 @@
+"""Event-driven cleanup of launcher-managed PersistentVolumeClaims.
+
+Watches Kubernetes Jobs and deletes the PVC(s) bound to a Job when that Job is
+deleted, so auto-provisioned volumes do not leak. PVCs are matched to their
+owning Job via the labels applied by
+:func:`kubernetes_launchers.create_managed_pvc`.
+
+Watch-only: there is no periodic reconcile sweep, so a Job deletion that happens
+while the watcher is down (process restart, crash) is not reaped. This is a
+deliberate minimality choice; the leak surface is bounded to Jobs deleted during
+watcher downtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import kubernetes.client.exceptions
+from kubernetes import client as k8s_client_lib
+from kubernetes import watch as k8s_watch_lib
+
+from . import kubernetes_launchers
+
+_logger = logging.getLogger(__name__)
+
+# Server-side watch timeout so a silently dropped connection recycles instead of
+# blocking forever. The watch is simply re-established when it expires.
+_WATCH_TIMEOUT_SECONDS = 300
+
+# How long to wait for the watch thread to exit when stopping.
+_STOP_JOIN_TIMEOUT_SECONDS = 10
+
+
+class KubernetesPVCReaper:
+    """Deletes launcher-managed PVCs when their owning Job is deleted.
+
+    Runs a single daemon thread that streams Job events in ``namespace`` and, on
+    each Job ``DELETED`` event, deletes the managed PVC(s) whose owner-job label
+    matches the deleted Job.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_client: k8s_client_lib.ApiClient,
+        namespace: str,
+        request_timeout: int | tuple[int, int] = 10,
+    ):
+        self._api_client = api_client
+        self._namespace = namespace
+        self._request_timeout = request_timeout
+        self._batch_client = k8s_client_lib.BatchV1Api(api_client)
+        self._core_client = k8s_client_lib.CoreV1Api(api_client)
+        self._managed_selector = (
+            f"{kubernetes_launchers.PVC_MANAGED_LABEL_KEY}"
+            f"={kubernetes_launchers.PVC_MANAGED_LABEL_VALUE}"
+        )
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @classmethod
+    def from_launcher(
+        cls,
+        launcher: kubernetes_launchers._KubernetesContainerLauncherBase,
+        **kwargs,
+    ) -> "KubernetesPVCReaper":
+        """Build a reaper reusing a launcher's Kubernetes client and namespace."""
+        return cls(
+            api_client=launcher._api_client,
+            namespace=launcher._namespace,
+            **kwargs,
+        )
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="kubernetes-pvc-reaper", daemon=True
+        )
+        self._thread.start()
+        _logger.info(f"PVC reaper started for namespace {self._namespace!r}")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        thread = self._thread
+        if thread is not None:
+            thread.join(timeout=_STOP_JOIN_TIMEOUT_SECONDS)
+        self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._watch_once()
+            except kubernetes.client.exceptions.ApiException as exc:
+                # 410 Gone: the resourceVersion is too old; the watch is simply
+                # re-established (from the latest state) on the next iteration.
+                if exc.status == 410:
+                    _logger.info("PVC reaper watch expired (410 Gone); restarting")
+                else:
+                    _logger.exception("PVC reaper watch error; restarting")
+            except Exception:
+                _logger.exception("PVC reaper watch error; restarting")
+
+    def _watch_once(self) -> None:
+        watch = k8s_watch_lib.Watch()
+        try:
+            for event in watch.stream(
+                self._batch_client.list_namespaced_job,
+                namespace=self._namespace,
+                timeout_seconds=_WATCH_TIMEOUT_SECONDS,
+            ):
+                if self._stop_event.is_set():
+                    break
+                self._handle_event(event)
+        finally:
+            watch.stop()
+
+    def _handle_event(self, event: dict) -> None:
+        if event.get("type") != "DELETED":
+            return
+        job = event.get("object")
+        metadata = getattr(job, "metadata", None)
+        job_name = getattr(metadata, "name", None)
+        if job_name:
+            self._reap_pvcs_for_job(job_name)
+
+    def _reap_pvcs_for_job(self, job_name: str) -> None:
+        selector = (
+            f"{self._managed_selector},"
+            f"{kubernetes_launchers.PVC_OWNER_JOB_NAME_LABEL_KEY}={job_name}"
+        )
+        try:
+            pvcs = self._core_client.list_namespaced_persistent_volume_claim(
+                namespace=self._namespace,
+                label_selector=selector,
+                _request_timeout=self._request_timeout,
+            )
+        except Exception:
+            _logger.exception(
+                f"PVC reaper: failed to list PVCs for deleted Job {job_name!r}"
+            )
+            return
+
+        for pvc in pvcs.items:
+            pvc_name = pvc.metadata.name
+            try:
+                self._core_client.delete_namespaced_persistent_volume_claim(
+                    name=pvc_name,
+                    namespace=self._namespace,
+                    _request_timeout=self._request_timeout,
+                )
+                _logger.info(
+                    f"PVC reaper: deleted PVC {pvc_name!r} after "
+                    f"Job {job_name!r} deletion"
+                )
+            except kubernetes.client.exceptions.ApiException as exc:
+                if exc.status == 404:
+                    # Already gone; nothing to do.
+                    continue
+                _logger.exception(f"PVC reaper: failed to delete PVC {pvc_name!r}")
+            except Exception:
+                _logger.exception(f"PVC reaper: failed to delete PVC {pvc_name!r}")

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -25,6 +25,9 @@ from .instrumentation import bugsnag_instrumentation
 from .instrumentation import contextual_logging
 from .instrumentation import metrics as app_metrics
 
+if typing.TYPE_CHECKING:
+    from .launchers import kubernetes_pvc_reaper
+
 _logger = logging.getLogger(__name__)
 
 _T = typing.TypeVar("_T")
@@ -51,12 +54,14 @@ class OrchestratorService_Sql:
         sleep_seconds_between_queue_sweeps: float = 1.0,
         output_data_purge_duration: datetime.timedelta = None,
         *,
+        pvc_reaper: "kubernetes_pvc_reaper.KubernetesPVCReaper | None" = None,
         # Internal/experimental:
         _max_queue_batch_size: int = 1,
         _max_queue_batch_duration: datetime.timedelta = datetime.timedelta(),
     ):
         self._session_factory = session_factory
         self._launcher = launcher
+        self._pvc_reaper = pvc_reaper
         self._storage_provider = storage_provider
         self._data_root_uri = data_root_uri
         self._logs_root_uri = logs_root_uri
@@ -70,13 +75,19 @@ class OrchestratorService_Sql:
         self._max_queue_batch_duration = _max_queue_batch_duration
 
     def run_loop(self):
-        while True:
-            try:
-                self.process_each_queue_once()
-                time.sleep(self._sleep_seconds_between_queue_sweeps)
-            except Exception as exc:
-                _logger.exception("Error while calling `process_each_queue_once`")
-                bugsnag_instrumentation.notify(exception=exc)
+        if self._pvc_reaper is not None:
+            self._pvc_reaper.start()
+        try:
+            while True:
+                try:
+                    self.process_each_queue_once()
+                    time.sleep(self._sleep_seconds_between_queue_sweeps)
+                except Exception as exc:
+                    _logger.exception("Error while calling `process_each_queue_once`")
+                    bugsnag_instrumentation.notify(exception=exc)
+        finally:
+            if self._pvc_reaper is not None:
+                self._pvc_reaper.stop()
 
     def process_each_queue_once(self):
         queue_handlers = [

--- a/tests/test_kubernetes_pvc_reaper.py
+++ b/tests/test_kubernetes_pvc_reaper.py
@@ -1,0 +1,124 @@
+"""Tests for cloud_pipelines_backend.launchers.kubernetes_pvc_reaper.
+
+The Kubernetes client is mocked so the tests run offline.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest import mock
+
+import kubernetes.client.exceptions
+
+from cloud_pipelines_backend.launchers import kubernetes_launchers
+from cloud_pipelines_backend.launchers import kubernetes_pvc_reaper
+
+
+def _make_reaper(
+    namespace: str = "test-ns",
+) -> "kubernetes_pvc_reaper.KubernetesPVCReaper":
+    reaper = kubernetes_pvc_reaper.KubernetesPVCReaper(
+        api_client=mock.MagicMock(),
+        namespace=namespace,
+    )
+    # Replace the real API clients built in __init__ with mocks.
+    reaper._core_client = mock.MagicMock()
+    reaper._batch_client = mock.MagicMock()
+    return reaper
+
+
+def _job_event(event_type: str, job_name: str) -> dict:
+    metadata = types.SimpleNamespace(name=job_name)
+    job = types.SimpleNamespace(metadata=metadata)
+    return {"type": event_type, "object": job}
+
+
+def _pvc_list(*pvc_names: str):
+    items = [
+        types.SimpleNamespace(metadata=types.SimpleNamespace(name=name))
+        for name in pvc_names
+    ]
+    return types.SimpleNamespace(items=items)
+
+
+def test_deleted_job_reaps_matching_pvc():
+    reaper = _make_reaper()
+    reaper._core_client.list_namespaced_persistent_volume_claim.return_value = (
+        _pvc_list("tangle-ce-abc")
+    )
+
+    reaper._handle_event(_job_event("DELETED", "tangle-ce-abc"))
+
+    # The PVC list is scoped to both the managed label and the owning Job name.
+    list_kwargs = (
+        reaper._core_client.list_namespaced_persistent_volume_claim.call_args.kwargs
+    )
+    selector = list_kwargs["label_selector"]
+    assert kubernetes_launchers.PVC_MANAGED_LABEL_KEY in selector
+    assert (
+        f"{kubernetes_launchers.PVC_OWNER_JOB_NAME_LABEL_KEY}=tangle-ce-abc" in selector
+    )
+
+    reaper._core_client.delete_namespaced_persistent_volume_claim.assert_called_once()
+    delete_kwargs = (
+        reaper._core_client.delete_namespaced_persistent_volume_claim.call_args.kwargs
+    )
+    assert delete_kwargs["name"] == "tangle-ce-abc"
+    assert delete_kwargs["namespace"] == "test-ns"
+
+
+def test_non_deleted_events_are_ignored():
+    reaper = _make_reaper()
+
+    for event_type in ("ADDED", "MODIFIED", "BOOKMARK"):
+        reaper._handle_event(_job_event(event_type, "tangle-ce-abc"))
+
+    reaper._core_client.list_namespaced_persistent_volume_claim.assert_not_called()
+    reaper._core_client.delete_namespaced_persistent_volume_claim.assert_not_called()
+
+
+def test_no_matching_pvc_deletes_nothing():
+    reaper = _make_reaper()
+    reaper._core_client.list_namespaced_persistent_volume_claim.return_value = (
+        _pvc_list()
+    )
+
+    reaper._handle_event(_job_event("DELETED", "some-unrelated-job"))
+
+    reaper._core_client.delete_namespaced_persistent_volume_claim.assert_not_called()
+
+
+def test_already_deleted_pvc_is_swallowed():
+    reaper = _make_reaper()
+    reaper._core_client.list_namespaced_persistent_volume_claim.return_value = (
+        _pvc_list("tangle-ce-abc")
+    )
+    reaper._core_client.delete_namespaced_persistent_volume_claim.side_effect = (
+        kubernetes.client.exceptions.ApiException(status=404)
+    )
+
+    # Should not raise.
+    reaper._reap_pvcs_for_job("tangle-ce-abc")
+
+
+def test_run_restarts_watch_after_410():
+    reaper = _make_reaper()
+    calls: list[int] = []
+
+    def fake_watch_once():
+        calls.append(1)
+        if len(calls) == 1:
+            raise kubernetes.client.exceptions.ApiException(status=410)
+        # Second pass: signal stop so _run exits.
+        reaper._stop_event.set()
+
+    reaper._watch_once = fake_watch_once
+    reaper._run()
+
+    assert len(calls) == 2
+
+
+def test_stop_before_start_is_safe():
+    reaper = _make_reaper()
+    # Should not raise even though the thread was never started.
+    reaper.stop()


### PR DESCRIPTION
## What & why

Auto-provisioned PVCs (`tangle-ce-<container_execution_id>`, on Nebius storage class `csi-mounted-fs-path-sc`) created for shared multi-node filesystem access are never deleted — this has leaked ~140 TiB. Today PVC creation lives only in the Shopify oasis launcher and sets no owner reference; the OSS layer has no PVC lifecycle at all.

This PR adds a **common, event-driven PVC cleanup mechanism in the OSS layer** so both the OSS kubernetes launcher and the downstream oasis GKE launcher benefit from one solution.

This is a **draft / alternative** to the ownerReference + Job-TTL wrapper approach in oasis-backend #398 (issue #379). It is offered for comparison — #398 stays open; the team picks one.

## Approach

- **`KubernetesPVCReaper`** (new `kubernetes_pvc_reaper.py`): a daemon thread that watches Job lifecycle events and, on each Job `DELETED` event, deletes the managed PVC(s) whose owner-job label matches. Reap trigger is **Job deletion** — PVC lifetime is tied to the Job object's existence.
- **Watch-only** (no reconcile sweep). Minimal resilience: reconnect on timeout, restart on 410-Gone. **Accepted tradeoff:** a Job deletion that occurs while the watcher is down is not reaped (no backstop). Deliberate minimality choice; leak surface bounded to watcher downtime.
- **`create_managed_pvc()` + label constants** in `kubernetes_launchers.py`: `tangleml.com/managed-pvc=true` (reaper scope) and `tangleml.com/owner-job-name=<job>` (PVC→Job map). Storage class stays caller-supplied (cloud-specific). Only auto-provisioned PVCs are labeled; user-supplied PVCs are never labeled/reaped.
- **Orchestrator** starts/stops an optional reaper around `run_loop`, so no launcher-specific cleanup code is needed.

## How it differs from #398

- No post-launch `ownerReference` patch dance (no Job-UID read race, no registry dict, no `blockOwnerDeletion` vs `pvc-protection` finalizer tuning).
- One general, label-driven OSS mechanism rather than a Nebius-only wrapper.
- Extensible to the orphaned multi-node headless `Service` (same lifecycle).

## Follow-ups (not in this PR)

- **Closing the loop:** with "reap only on Job deletion," finished Jobs must eventually be deleted or their PVCs never reap. Recommend a Job `ttlSecondsAfterFinished` in `_KubernetesJobLauncher` as the deletion trigger. Deliberately left out to keep this PR minimal.
- **oasis-backend:** switch the Nebius auto-provisioned PVC path to `create_managed_pvc` (held until this lands, per submodule-first policy).

## Testing

`tests/test_kubernetes_pvc_reaper.py` (offline, mocked `ApiClient`): DELETED event → PVC deleted; managed-label + owner-job scoping; non-DELETED events ignored; already-gone PVC (404) swallowed; watch restart after 410. Full suite: 443 passed.