### PR TITLE
chore: API Server - Return 409 instead of 500 when container execution not yet available

### DIFF
--- a/cloud_pipelines_backend/api_router.py
+++ b/cloud_pipelines_backend/api_router.py
@@ -108,6 +108,19 @@ def _setup_routes_internal(
             response.headers["x-tangle-request-id"] = request_id
         return response
 
+    @app.exception_handler(errors.ContainerExecutionNotReadyError)
+    def handle_container_execution_not_ready_error(
+        request: fastapi.Request, exc: errors.ContainerExecutionNotReadyError
+    ):
+        return fastapi.responses.JSONResponse(
+            status_code=fastapi.status.HTTP_409_CONFLICT,
+            content={
+                "reason": "container_not_ready",
+                "execution_status": exc.execution_status,
+                "message": str(exc),
+            },
+        )
+
     @app.exception_handler(errors.PermissionError)
     def handle_permission_error(request: fastapi.Request, exc: errors.PermissionError):
         response = fastapi.responses.JSONResponse(

--- a/cloud_pipelines_backend/api_server_sql.py
+++ b/cloud_pipelines_backend/api_server_sql.py
@@ -761,8 +761,9 @@ class ExecutionNodesApiService_Sql:
             raise errors.ItemNotFoundError(f"Execution with {id=} does not exist.")
         container_execution = execution.container_execution
         if not container_execution:
-            raise RuntimeError(
-                f"Execution with {id=} does not have container execution information."
+            raise errors.ContainerExecutionNotReadyError(
+                execution_node_id=id,
+                execution_status=execution.container_execution_status,
             )
 
         if include_execution_nodes_linked_to_same_container_execution:
@@ -890,8 +891,9 @@ class ExecutionNodesApiService_Sql:
                     system_error_exception_full=system_error_exception_full,
                     orchestration_error_message=orchestration_error_message,
                 )
-            raise RuntimeError(
-                f"Execution with {id=} does not have container execution information."
+            raise errors.ContainerExecutionNotReadyError(
+                execution_node_id=id,
+                execution_status=execution.container_execution_status,
             )
         log_text: str | None = None
         if container_execution.status in (
@@ -961,8 +963,9 @@ class ExecutionNodesApiService_Sql:
             )
         container_execution = execution.container_execution
         if not container_execution:
-            raise ApiServiceError(
-                "Execution does not have container execution information."
+            raise errors.ContainerExecutionNotReadyError(
+                execution_node_id=execution_id,
+                execution_status=execution.container_execution_status,
             )
         if not container_execution.launcher_data:
             raise ApiServiceError(

--- a/cloud_pipelines_backend/errors.py
+++ b/cloud_pipelines_backend/errors.py
@@ -2,6 +2,18 @@ class ItemNotFoundError(Exception):
     pass
 
 
+class ContainerExecutionNotReadyError(Exception):
+    """Execution exists but its container execution is not yet available (transient)."""
+
+    def __init__(self, *, execution_node_id: str, execution_status: str | None = None):
+        self.execution_node_id = execution_node_id
+        self.execution_status = execution_status
+        super().__init__(
+            f"Execution with {execution_node_id=} does not have "
+            "container execution information."
+        )
+
+
 class ItemAlreadyExistsError(Exception):
     pass
 

--- a/tests/test_execution_nodes_api_service.py
+++ b/tests/test_execution_nodes_api_service.py
@@ -6,6 +6,7 @@ from sqlalchemy import orm
 from cloud_pipelines_backend import backend_types_sql as bts
 from cloud_pipelines_backend import component_structures as structures
 from cloud_pipelines_backend import database_ops
+from cloud_pipelines_backend import errors
 from cloud_pipelines_backend.api_server_sql import (
     ExecutionNodesApiService_Sql,
     GetExecutionInfoResponse,
@@ -408,6 +409,37 @@ class TestGetExecutionInfo:
 
         assert result.status_history is not None
         assert [e.status for e in result.status_history] == ["QUEUED"]
+
+
+class TestGetContainerExecutionState:
+    """Tests for ExecutionNodesApiService_Sql.get_container_execution_state."""
+
+    def setup_method(self):
+        self.session_factory = _initialize_db_and_get_session_factory()
+        self.service = ExecutionNodesApiService_Sql()
+
+    def test_pending_without_container_row_raises_not_ready(self):
+        """PENDING node with no ContainerExecution yet is a transient state, not a 500."""
+        with self.session_factory() as session:
+            node = _make_execution_node(
+                task_spec=_make_task_spec_dict(),
+                container_execution_status=bts.ContainerExecutionStatus.PENDING,
+            )
+            session.add(node)
+            session.flush()
+
+            with pytest.raises(errors.ContainerExecutionNotReadyError) as exc_info:
+                self.service.get_container_execution_state(session=session, id=node.id)
+
+        assert exc_info.value.execution_status == bts.ContainerExecutionStatus.PENDING
+
+    def test_missing_execution_still_raises_not_found(self):
+        """A genuinely absent execution remains an ItemNotFoundError (404)."""
+        with self.session_factory() as session:
+            with pytest.raises(errors.ItemNotFoundError):
+                self.service.get_container_execution_state(
+                    session=session, id="does-not-exist"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #296

## Problem

Three read endpoints return **500 + a Bugsnag notification** when an `ExecutionNode` exists but has no linked `ContainerExecution` row:

- `GET /api/executions/{id}/container_state`
- `GET /api/executions/{id}/container_log`
- `GET /api/executions/{id}/stream_container_log`

They gate on the relationship (`if not execution.container_execution`) and raised `RuntimeError`/`ApiServiceError`, which had no handler in `api_router.py`, so they fell through to the catch-all `Exception` handler → 500 + Bugsnag.

A node can legitimately have no container row in several committed states — `container_execution_status` and `container_execution` are **independent columns** with no invariant coupling them:

- **Graph / sub-pipeline nodes** — never launch a container; their status stays `None` permanently. The frontend polls these (its fetch fires on `!status`), so this is the dominant, guaranteed source of the noise.
- **Pre-launch container nodes** — `QUEUED` / `WAITING_FOR_UPSTREAM` before the orchestrator launches; hit by direct API callers (tangle-deploy, operator scripts).
- **Admin status override** (`PUT /api/admin/execution_node/{id}/status`) — can set any status, including `PENDING`, without a container link.

In all of these the condition is expected, not a server fault. The recurring 500s also buried genuine `execution does not exist` 404s under expected-state noise. (Note: the orchestrator's normal launch/reuse paths do **not** produce this — they write status and link atomically in one transaction; full analysis in the investigation doc.)

## Changes

- **`errors.py`** — new `ContainerExecutionNotReadyError` carrying `execution_status`, distinct from `ItemNotFoundError` (which means the execution itself is absent).
- **`api_server_sql.py`** — raise it at all three sites when the node exists but `container_execution` is `None`, unifying the previous `RuntimeError` + `ApiServiceError`. The existing graceful `SYSTEM_ERROR`-with-no-row path is unchanged.
- **`api_router.py`** — handler mapping it to **409 Conflict** with a machine-readable body: `{"reason": "container_not_ready", "execution_status": "<status-or-null>", "message": "..."}`.

The fix keys off the container link (not the status), so it covers every case above regardless of the node's status.

## System impact

The dedicated `ContainerExecutionNotReadyError` handler is more specific than the catch-all `Exception` handler in `api_server_main.py`, so it takes precedence and **Bugsnag is not notified** on this path. Genuine `execution does not exist` still returns **404**.

| | Before | After |
|---|---|---|
| Node exists, no container row (graph node, pre-launch, etc.) | 500 + Bugsnag event | 409, no Bugsnag |
| Execution absent | 404 | 404 (unchanged) |

## Tests

Two focused service-level tests: a node with no container row raises `ContainerExecutionNotReadyError` (with `execution_status` populated), and a genuinely absent execution still raises `ItemNotFoundError`.
