### PR TITLE
Add opt-in single-node Kubernetes Jobs

### DIFF
--- a/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
@@ -54,7 +54,12 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesJobLauncher(
 class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
     kubernetes_launchers._KubernetesPodOrJobLauncher
 ):
-    """Launcher that uses Google Kubernetes Engine to launch Kubernetes Pods or Jobs (uses GKE-gcsfuse driver for data passing)"""
+    """GKE/GCS launcher with selectable single-node Pod or Job mode.
+
+    Single-node tasks default to Pods. ``single_node_execution_mode`` or the
+    per-task execution-mode annotation can select a NonIndexed Job; multi-node
+    annotations always select an Indexed Job.
+    """
 
     def __init__(
         self,
@@ -67,6 +72,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: kubernetes_launchers.PodPostProcessor | None = None,
+        single_node_execution_mode: typing.Literal["pod", "job"] = "pod",
     ):
         pod_postprocessors = [
             kubernetes_launchers._google_kubernetes_engine_accelerator_pod_postprocessor
@@ -85,6 +91,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
             pod_labels=pod_labels,
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,
+            single_node_execution_mode=single_node_execution_mode,
             _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
                 gcs_client
             ),

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -52,6 +52,9 @@ RESOURCES_ACCELERATORS_ANNOTATION_KEY = (
 MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY = (
     "tangleml.com/launchers/kubernetes/multi_node/number_of_nodes"
 )
+SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY = (
+    "tangleml.com/launchers/kubernetes/single_node/execution_mode"
+)
 SECURITY_CONTEXT_CAPABILITY_IPC_LOCK_ANNOTATION_KEY = (
     "tangleml.com/launchers/kubernetes/security_context.capability.IPC_LOCK"
 )
@@ -68,6 +71,23 @@ _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY = "system/multi_node/all_node_ad
 
 # Environment variables for multi-node execution.
 _MULTI_NODE_NODE_INDEX_ENV_VAR_NAME = "_TANGLE_MULTI_NODE_NODE_INDEX"
+
+_SINGLE_NODE_DYNAMIC_DATA_VALUES = {
+    _MULTI_NODE_NUMBER_OF_NODES_DYNAMIC_DATA_KEY: "1",
+    _MULTI_NODE_NODE_INDEX_DYNAMIC_DATA_KEY: "0",
+    _MULTI_NODE_NODE_0_ADDRESS_DYNAMIC_DATA_KEY: "localhost",
+    _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY: "localhost",
+}
+
+
+def _validate_single_node_execution_mode(
+    value: Any,
+) -> typing.Literal["pod", "job"]:
+    if value not in ("pod", "job"):
+        raise interfaces.LauncherError(
+            f"Invalid single-node execution mode {value!r}. Expected 'pod' or 'job'."
+        )
+    return typing.cast(typing.Literal["pod", "job"], value)
 
 
 _T = typing.TypeVar("_T")
@@ -522,12 +542,7 @@ class _KubernetesPodLauncher(
         # Resolving the dynamic data arguments
         # Since pod-based launcher cannot launch multiple nodes, we could have chosen to fail when encountering multi-node arguments.
         # However it's possible to provide sensible values for them.
-        known_dynamic_data_values = {
-            _MULTI_NODE_NUMBER_OF_NODES_DYNAMIC_DATA_KEY: "1",
-            _MULTI_NODE_NODE_INDEX_DYNAMIC_DATA_KEY: "0",
-            _MULTI_NODE_NODE_0_ADDRESS_DYNAMIC_DATA_KEY: "localhost",
-            _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY: "localhost",
-        }
+        known_dynamic_data_values = _SINGLE_NODE_DYNAMIC_DATA_VALUES
         for input_name, input_argument in list(input_arguments.items()):
             if input_argument.value is not None or input_argument.uri is not None:
                 continue
@@ -1028,6 +1043,43 @@ class _KubernetesJobLauncher(
         log_uri: str,
         annotations: dict[str, Any] | None = None,
     ) -> "LaunchedKubernetesJob":
+        return self._launch_container_task(
+            component_spec=component_spec,
+            input_arguments=input_arguments,
+            output_uris=output_uris,
+            log_uri=log_uri,
+            annotations=annotations,
+            single_node_job=False,
+        )
+
+    def launch_single_node_container_task(
+        self,
+        *,
+        component_spec: structures.ComponentSpec,
+        input_arguments: dict[str, interfaces.InputArgument],
+        output_uris: dict[str, str],
+        log_uri: str,
+        annotations: dict[str, Any] | None = None,
+    ) -> "LaunchedKubernetesJob":
+        return self._launch_container_task(
+            component_spec=component_spec,
+            input_arguments=input_arguments,
+            output_uris=output_uris,
+            log_uri=log_uri,
+            annotations=annotations,
+            single_node_job=True,
+        )
+
+    def _launch_container_task(
+        self,
+        *,
+        component_spec: structures.ComponentSpec,
+        input_arguments: dict[str, interfaces.InputArgument],
+        output_uris: dict[str, str],
+        log_uri: str,
+        annotations: dict[str, Any] | None,
+        single_node_job: bool,
+    ) -> "LaunchedKubernetesJob":
         namespace = self._choose_namespace(annotations=annotations)
 
         # We have 2 options regarding job name:
@@ -1052,7 +1104,7 @@ class _KubernetesJobLauncher(
             explicit_resource_name = resource_name_prefix + container_execution_id
         else:
             _logger.warning(
-                "Should not happen: Container execution ID annotation is required for multi-node execution, but it was not found."
+                "Should not happen: Container execution ID annotation is required for Kubernetes Job execution, but it was not found."
             )
             import uuid
 
@@ -1060,15 +1112,19 @@ class _KubernetesJobLauncher(
 
         explicit_job_name = explicit_resource_name
 
-        num_nodes_annotation_str = (annotations or {}).get(
-            MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY, 1
-        )
-        enable_multi_node = num_nodes_annotation_str is not None
-        num_nodes = int(num_nodes_annotation_str) if num_nodes_annotation_str else 1
-        if not (0 < num_nodes <= _MULTI_NODE_MAX_NUMBER_OF_NODES):
-            raise interfaces.LauncherError(
-                f"Invalid number of nodes for multi-node execution. Number of nodes must be between 1 and {_MULTI_NODE_MAX_NUMBER_OF_NODES}, but got {num_nodes}."
+        if single_node_job:
+            enable_multi_node = False
+            num_nodes = 1
+        else:
+            num_nodes_annotation_str = (annotations or {}).get(
+                MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY, 1
             )
+            enable_multi_node = num_nodes_annotation_str is not None
+            num_nodes = int(num_nodes_annotation_str) if num_nodes_annotation_str else 1
+            if not (0 < num_nodes <= _MULTI_NODE_MAX_NUMBER_OF_NODES):
+                raise interfaces.LauncherError(
+                    f"Invalid number of nodes for multi-node execution. Number of nodes must be between 1 and {_MULTI_NODE_MAX_NUMBER_OF_NODES}, but got {num_nodes}."
+                )
         explicit_service_name = explicit_resource_name
         if enable_multi_node:
             all_node_addresses = [
@@ -1086,13 +1142,17 @@ class _KubernetesJobLauncher(
             all_node_addresses_str = node_0_address
 
         # Resolving the dynamic data arguments
-        known_dynamic_data_values = {
-            _MULTI_NODE_NUMBER_OF_NODES_DYNAMIC_DATA_KEY: str(num_nodes),
-            # Using Kubernetes' env variable substitution to inject the node index into the container since it's not known at the time of pod creation.
-            _MULTI_NODE_NODE_INDEX_DYNAMIC_DATA_KEY: f"$({_MULTI_NODE_NODE_INDEX_ENV_VAR_NAME})",
-            _MULTI_NODE_NODE_0_ADDRESS_DYNAMIC_DATA_KEY: node_0_address,
-            _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY: all_node_addresses_str,
-        }
+        known_dynamic_data_values = (
+            _SINGLE_NODE_DYNAMIC_DATA_VALUES
+            if single_node_job
+            else {
+                _MULTI_NODE_NUMBER_OF_NODES_DYNAMIC_DATA_KEY: str(num_nodes),
+                # The completion index is only available when the Job's Pods are created.
+                _MULTI_NODE_NODE_INDEX_DYNAMIC_DATA_KEY: f"$({_MULTI_NODE_NODE_INDEX_ENV_VAR_NAME})",
+                _MULTI_NODE_NODE_0_ADDRESS_DYNAMIC_DATA_KEY: node_0_address,
+                _MULTI_NODE_ALL_NODE_ADDRESSES_DYNAMIC_DATA_KEY: all_node_addresses_str,
+            }
+        )
 
         for input_name, input_argument in list(input_arguments.items()):
             if input_argument.value is not None or input_argument.uri is not None:
@@ -1185,27 +1245,34 @@ class _KubernetesJobLauncher(
             # This requires the service name to be known.
             pod.spec.subdomain = explicit_service_name
 
-        job = k8s_client_lib.V1Job(
-            metadata=k8s_client_lib.V1ObjectMeta(
-                name=explicit_job_name,
-                namespace=namespace,
-                # annotations=self._pod_annotations,
-                # labels=self._pod_labels,
-            ),
-            spec=k8s_client_lib.V1JobSpec(
-                template=k8s_client_lib.V1PodTemplateSpec(
-                    metadata=pod.metadata,
-                    spec=pod.spec,
-                ),
-                # Let's always use Indexed Jobs. There are no downsides.
+        pod_template = k8s_client_lib.V1PodTemplateSpec(
+            metadata=pod.metadata,
+            spec=pod.spec,
+        )
+        if single_node_job:
+            job_spec = k8s_client_lib.V1JobSpec(
+                template=pod_template,
+                completion_mode="NonIndexed",
+                completions=1,
+                parallelism=1,
+                backoff_limit=0,
+            )
+        else:
+            job_spec = k8s_client_lib.V1JobSpec(
+                template=pod_template,
                 completion_mode="Indexed",
-                # backoff_limit=0,
                 backoff_limit_per_index=0,
                 # Without explicit max_failed_indexes=0, the job waits for all pods to end and then succeeds ("Complete") despite pod failures!
                 max_failed_indexes=0,
                 completions=num_nodes,
                 parallelism=num_nodes,
+            )
+        job = k8s_client_lib.V1Job(
+            metadata=k8s_client_lib.V1ObjectMeta(
+                name=explicit_job_name,
+                namespace=namespace,
             ),
+            spec=job_spec,
         )
 
         job = self._transform_job_before_launching(job=job, annotations=annotations)
@@ -1235,6 +1302,7 @@ class _KubernetesJobLauncher(
             debug_pods={},
             cluster_server=self._api_client.configuration.host,
             launcher=self,
+            single_node_job=single_node_job,
         )
 
         return launched_container
@@ -1274,6 +1342,7 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
         debug_pods: dict[str, k8s_client_lib.V1Pod] | None = None,
         cluster_server: str | None = None,
         launcher: _KubernetesJobLauncher | None = None,
+        single_node_job: bool = False,
     ):
         self._job_name = job_name
         self._namespace = namespace
@@ -1283,6 +1352,7 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
         self._debug_pods: dict[str, k8s_client_lib.V1Pod] = debug_pods or {}
         self._cluster_server = cluster_server
         self._launcher = launcher
+        self._single_node_job = single_node_job
 
     def _get_launcher(self):
         if not self._launcher:
@@ -1400,19 +1470,19 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
                 )
                 for pod_name, pod in self._debug_pods.items()
             }
-        result = {
-            self.SERIALIZATION_ROOT_KEY: dict(
-                launched_container_class_name=self.__class__.__name__,
-                job_name=self._job_name,
-                namespace=self._namespace,
-                cluster_server=self._cluster_server,
-                output_uris=self._output_uris,
-                log_uri=self._log_uri,
-                debug_job=job_dict,
-                debug_pods=pod_dicts,
-            ),
-        }
-        return result
+        launcher_data = dict(
+            launched_container_class_name=self.__class__.__name__,
+            job_name=self._job_name,
+            namespace=self._namespace,
+            cluster_server=self._cluster_server,
+            output_uris=self._output_uris,
+            log_uri=self._log_uri,
+            debug_job=job_dict,
+            debug_pods=pod_dicts,
+        )
+        if self._single_node_job:
+            launcher_data["single_node_job"] = True
+        return {self.SERIALIZATION_ROOT_KEY: launcher_data}
 
     @classmethod
     def from_dict(
@@ -1444,6 +1514,7 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
             debug_job=debug_job,
             debug_pods=debug_pods,
             launcher=launcher,
+            single_node_job=d.get("single_node_job", False),
         )
 
     def get_refreshed(self) -> "LaunchedKubernetesJob":
@@ -1622,7 +1693,11 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
 class _KubernetesPodOrJobLauncher(
     interfaces.ContainerTaskLauncher[interfaces.LaunchedContainer],
 ):
-    """Launcher that launches Kubernetes Pods or Jobs"""
+    """Launches single-node tasks as Pods by default and multi-node tasks as Indexed Jobs.
+
+    ``single_node_execution_mode`` or the per-task execution-mode annotation can
+    select a NonIndexed Job. A multi-node annotation always takes precedence.
+    """
 
     def __init__(
         self,
@@ -1634,12 +1709,16 @@ class _KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        single_node_execution_mode: typing.Literal["pod", "job"] = "pod",
         _storage_provider: storage_provider_interfaces.StorageProvider,
         _create_volume_and_volume_mount: typing.Callable[
             [str, str, str, bool],
             tuple[k8s_client_lib.V1Volume, k8s_client_lib.V1VolumeMount],
         ],
     ):
+        self._single_node_execution_mode = _validate_single_node_execution_mode(
+            single_node_execution_mode
+        )
         self._pod_launcher = _KubernetesPodLauncher(
             api_client=api_client,
             namespace=namespace,
@@ -1677,7 +1756,8 @@ class _KubernetesPodOrJobLauncher(
         log_uri: str,
         annotations: dict[str, Any] | None = None,
     ) -> "LaunchedKubernetesContainer | LaunchedKubernetesJob":
-        if annotations and MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY in annotations:
+        task_annotations = annotations or {}
+        if MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY in task_annotations:
             return self._job_launcher.launch_container_task(
                 component_spec=component_spec,
                 input_arguments=input_arguments,
@@ -1685,14 +1765,25 @@ class _KubernetesPodOrJobLauncher(
                 log_uri=log_uri,
                 annotations=annotations,
             )
-        else:
-            return self._pod_launcher.launch_container_task(
-                component_spec=component_spec,
-                input_arguments=input_arguments,
-                output_uris=output_uris,
-                log_uri=log_uri,
-                annotations=annotations,
+
+        execution_mode = _validate_single_node_execution_mode(
+            task_annotations.get(
+                SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY,
+                self._single_node_execution_mode,
             )
+        )
+        launcher = (
+            self._job_launcher.launch_single_node_container_task
+            if execution_mode == "job"
+            else self._pod_launcher.launch_container_task
+        )
+        return launcher(
+            component_spec=component_spec,
+            input_arguments=input_arguments,
+            output_uris=output_uris,
+            log_uri=log_uri,
+            annotations=annotations,
+        )
 
     def get_refreshed_launched_container_from_dict(
         self, launched_container_dict: dict
@@ -1750,6 +1841,8 @@ class Local_Kubernetes_UsingHostPathStorage_KubernetesJobLauncher(
 class Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
     _KubernetesPodOrJobLauncher
 ):
+    """Local-storage Kubernetes launcher with selectable single-node Pod or Job mode."""
+
     def __init__(
         self,
         *,
@@ -1760,6 +1853,7 @@ class Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        single_node_execution_mode: typing.Literal["pod", "job"] = "pod",
     ):
         super().__init__(
             namespace=namespace,
@@ -1769,6 +1863,7 @@ class Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
             pod_labels=pod_labels,
             pod_annotations=pod_annotations,
             pod_postprocessor=pod_postprocessor,
+            single_node_execution_mode=single_node_execution_mode,
             _storage_provider=local_storage.LocalStorageProvider(),
             _create_volume_and_volume_mount=_create_volume_and_volume_mount_host_path,
         )

--- a/tests/test_kubernetes_launchers.py
+++ b/tests/test_kubernetes_launchers.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+from kubernetes import client as k8s_client_lib
+
+from cloud_pipelines_backend import component_structures as structures
+from cloud_pipelines_backend.launchers import common_annotations
+from cloud_pipelines_backend.launchers import interfaces
+from cloud_pipelines_backend.launchers import kubernetes_launchers as kl
+
+
+def _component(*, dynamic_inputs: bool = False) -> structures.ComponentSpec:
+    input_names = [
+        "number_of_nodes",
+        "node_index",
+        "node_0_address",
+        "all_node_addresses",
+    ]
+    return structures.ComponentSpec(
+        name="test-component",
+        inputs=(
+            [structures.InputSpec(name=name) for name in input_names]
+            if dynamic_inputs
+            else []
+        ),
+        implementation=structures.ContainerImplementation(
+            container=structures.ContainerSpec(
+                image="python:3.12",
+                command=["echo"],
+                args=(
+                    [
+                        structures.InputValuePlaceholder(input_name=name)
+                        for name in input_names
+                    ]
+                    if dynamic_inputs
+                    else ["ok"]
+                ),
+            )
+        ),
+    )
+
+
+def _dynamic_input_arguments() -> dict[str, interfaces.InputArgument]:
+    dynamic_data_by_input = {
+        "number_of_nodes": "system/multi_node/number_of_nodes",
+        "node_index": "system/multi_node/node_index",
+        "node_0_address": "system/multi_node/node_0_address",
+        "all_node_addresses": "system/multi_node/all_node_addresses",
+    }
+    return {
+        name: interfaces.InputArgument(
+            total_size=0,
+            is_dir=False,
+            staging_uri="",
+            dynamic_data=dynamic_data,
+        )
+        for name, dynamic_data in dynamic_data_by_input.items()
+    }
+
+
+def _launch_kwargs(*, dynamic_inputs: bool = False) -> dict:
+    return {
+        "component_spec": _component(dynamic_inputs=dynamic_inputs),
+        "input_arguments": (_dynamic_input_arguments() if dynamic_inputs else {}),
+        "output_uris": {},
+        "log_uri": "file:///tmp/tangle-test.log",
+    }
+
+
+@pytest.fixture
+def api_client():
+    client = mock.Mock()
+    client.configuration.host = "https://kubernetes.example.test"
+    with mock.patch.object(kl.k8s_client_lib, "VersionApi") as version_api:
+        version_api.return_value.get_code.return_value = object()
+        yield client
+
+
+@pytest.fixture
+def kubernetes_apis(monkeypatch):
+    core_api = mock.Mock()
+    batch_api = mock.Mock()
+
+    def create_pod(*, namespace, body, **_kwargs):
+        body.metadata.name = (
+            body.metadata.name or f"{body.metadata.generate_name}abc123"
+        )
+        body.metadata.namespace = body.metadata.namespace or namespace
+        return body
+
+    def create_service(*, namespace, body, **_kwargs):
+        body.metadata.namespace = body.metadata.namespace or namespace
+        return body
+
+    def create_job(*, namespace, body, **_kwargs):
+        body.metadata.namespace = body.metadata.namespace or namespace
+        return body
+
+    core_api.create_namespaced_pod.side_effect = create_pod
+    core_api.create_namespaced_service.side_effect = create_service
+    batch_api.create_namespaced_job.side_effect = create_job
+    monkeypatch.setattr(
+        kl.k8s_client_lib, "CoreV1Api", lambda *args, **kwargs: core_api
+    )
+    monkeypatch.setattr(
+        kl.k8s_client_lib, "BatchV1Api", lambda *args, **kwargs: batch_api
+    )
+    return SimpleNamespace(core=core_api, batch=batch_api)
+
+
+def test_unconfigured_single_node_defaults_to_pod(api_client):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client
+    )
+    expected = object()
+    launcher._pod_launcher.launch_container_task = mock.Mock(return_value=expected)
+    launcher._job_launcher.launch_single_node_container_task = mock.Mock()
+
+    result = launcher.launch_container_task(**_launch_kwargs())
+
+    assert result is expected
+    launcher._pod_launcher.launch_container_task.assert_called_once()
+    launcher._job_launcher.launch_single_node_container_task.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("constructor_mode", "annotation_mode", "expected_mode"),
+    [
+        ("pod", None, "pod"),
+        ("job", None, "job"),
+        ("pod", "job", "job"),
+        ("job", "pod", "pod"),
+    ],
+)
+def test_single_node_default_and_annotation_route_tasks(
+    api_client, constructor_mode, annotation_mode, expected_mode
+):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client,
+        single_node_execution_mode=constructor_mode,
+    )
+    pod_result = object()
+    job_result = object()
+    launcher._pod_launcher.launch_container_task = mock.Mock(return_value=pod_result)
+    launcher._job_launcher.launch_single_node_container_task = mock.Mock(
+        return_value=job_result
+    )
+    launcher._job_launcher.launch_container_task = mock.Mock()
+    annotations = (
+        {kl.SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY: annotation_mode}
+        if annotation_mode
+        else None
+    )
+
+    result = launcher.launch_container_task(
+        **_launch_kwargs(),
+        annotations=annotations,
+    )
+
+    assert result is (job_result if expected_mode == "job" else pod_result)
+    assert launcher._pod_launcher.launch_container_task.call_count == (
+        expected_mode == "pod"
+    )
+    assert launcher._job_launcher.launch_single_node_container_task.call_count == (
+        expected_mode == "job"
+    )
+    launcher._job_launcher.launch_container_task.assert_not_called()
+
+
+def test_google_hybrid_constructor_threads_single_node_default(api_client, monkeypatch):
+    provider_module_name = (
+        "cloud_pipelines.orchestration.storage_providers.google_cloud_storage"
+    )
+    provider_module = types.ModuleType(provider_module_name)
+    provider_module.GoogleCloudStorageProvider = mock.Mock(return_value=mock.Mock())
+    monkeypatch.setitem(sys.modules, provider_module_name, provider_module)
+    launcher_module_name = (
+        "cloud_pipelines_backend.launchers.google_kubernetes_launchers"
+    )
+    sys.modules.pop(launcher_module_name, None)
+    try:
+        google_launchers = importlib.import_module(launcher_module_name)
+        launcher = google_launchers.GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
+            api_client=api_client,
+            gcs_client=mock.Mock(),
+            single_node_execution_mode="job",
+        )
+        expected = object()
+        launcher._job_launcher.launch_single_node_container_task = mock.Mock(
+            return_value=expected
+        )
+
+        result = launcher.launch_container_task(**_launch_kwargs())
+
+        assert result is expected
+        launcher._job_launcher.launch_single_node_container_task.assert_called_once()
+    finally:
+        sys.modules.pop(launcher_module_name, None)
+
+
+def test_invalid_single_node_modes_fail_before_dispatch(api_client):
+    with pytest.raises(
+        interfaces.LauncherError, match="Invalid single-node execution mode"
+    ):
+        kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+            api_client=api_client,
+            single_node_execution_mode="invalid",
+        )
+
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client
+    )
+    launcher._pod_launcher.launch_container_task = mock.Mock()
+    launcher._job_launcher.launch_single_node_container_task = mock.Mock()
+    launcher._job_launcher.launch_container_task = mock.Mock()
+
+    with pytest.raises(
+        interfaces.LauncherError, match="Invalid single-node execution mode"
+    ):
+        launcher.launch_container_task(
+            **_launch_kwargs(),
+            annotations={kl.SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY: "invalid"},
+        )
+
+    launcher._pod_launcher.launch_container_task.assert_not_called()
+    launcher._job_launcher.launch_single_node_container_task.assert_not_called()
+    launcher._job_launcher.launch_container_task.assert_not_called()
+
+
+def test_multi_node_annotation_takes_precedence_over_single_node_mode(api_client):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client,
+        single_node_execution_mode="job",
+    )
+    expected = object()
+    launcher._pod_launcher.launch_container_task = mock.Mock()
+    launcher._job_launcher.launch_single_node_container_task = mock.Mock()
+    launcher._job_launcher.launch_container_task = mock.Mock(return_value=expected)
+
+    result = launcher.launch_container_task(
+        **_launch_kwargs(),
+        annotations={
+            kl.MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY: "2",
+            kl.SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY: "invalid",
+        },
+    )
+
+    assert result is expected
+    launcher._job_launcher.launch_container_task.assert_called_once()
+    launcher._job_launcher.launch_single_node_container_task.assert_not_called()
+    launcher._pod_launcher.launch_container_task.assert_not_called()
+
+
+def test_single_node_job_shape_dynamic_values_and_serialization(
+    api_client, kubernetes_apis
+):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client,
+        service_account_name="task-runner",
+        pod_labels={"example.test/workload": "training"},
+        pod_annotations={"example.test/owner": "test"},
+        single_node_execution_mode="job",
+    )
+
+    launched = launcher.launch_container_task(
+        **_launch_kwargs(dynamic_inputs=True),
+        annotations={
+            common_annotations.CONTAINER_EXECUTION_ID_ANNOTATION_KEY: "single-node-123"
+        },
+    )
+
+    job = kubernetes_apis.batch.create_namespaced_job.call_args.kwargs["body"]
+    assert job.spec.completion_mode == "NonIndexed"
+    assert job.spec.completions == 1
+    assert job.spec.parallelism == 1
+    assert job.spec.backoff_limit == 0
+    assert job.spec.backoff_limit_per_index is None
+    assert job.spec.max_failed_indexes is None
+    assert job.spec.pod_replacement_policy is None
+
+    pod_template = job.spec.template
+    pod_spec = pod_template.spec
+    main_container = pod_spec.containers[0]
+    assert pod_spec.restart_policy == "Never"
+    assert pod_spec.service_account_name == "task-runner"
+    assert pod_spec.hostname is None
+    assert pod_spec.subdomain is None
+    assert pod_template.metadata.labels == {"example.test/workload": "training"}
+    assert pod_template.metadata.annotations["example.test/owner"] == "test"
+    assert main_container.args == ["1", "0", "localhost", "localhost"]
+    assert kl._MULTI_NODE_NODE_INDEX_ENV_VAR_NAME not in {
+        env.name for env in main_container.env or []
+    }
+    kubernetes_apis.core.create_namespaced_service.assert_not_called()
+
+    serialized = launched.to_dict()
+    launcher_data = serialized[kl.LaunchedKubernetesJob.SERIALIZATION_ROOT_KEY]
+    assert launcher_data["single_node_job"] is True
+    restored = kl.LaunchedKubernetesJob.from_dict(serialized)
+    assert restored.to_dict() == serialized
+
+
+def test_multi_node_indexed_job_shape_is_unchanged(api_client, kubernetes_apis):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesPodOrJobLauncher(
+        api_client=api_client,
+        single_node_execution_mode="job",
+    )
+
+    launched = launcher.launch_container_task(
+        **_launch_kwargs(dynamic_inputs=True),
+        annotations={
+            common_annotations.CONTAINER_EXECUTION_ID_ANNOTATION_KEY: "multi-node-123",
+            kl.MULTI_NODE_NUMBER_OF_NODES_ANNOTATION_KEY: "2",
+            kl.SINGLE_NODE_EXECUTION_MODE_ANNOTATION_KEY: "pod",
+        },
+    )
+
+    job = kubernetes_apis.batch.create_namespaced_job.call_args.kwargs["body"]
+    assert job.spec.completion_mode == "Indexed"
+    assert job.spec.completions == 2
+    assert job.spec.parallelism == 2
+    assert job.spec.backoff_limit is None
+    assert job.spec.backoff_limit_per_index == 0
+    assert job.spec.max_failed_indexes == 0
+
+    pod_spec = job.spec.template.spec
+    main_container = pod_spec.containers[0]
+    assert pod_spec.restart_policy == "Never"
+    assert pod_spec.subdomain == "tangle-ce-multi-node-123"
+    completion_index_env = main_container.env[0]
+    assert completion_index_env.name == kl._MULTI_NODE_NODE_INDEX_ENV_VAR_NAME
+    assert (
+        completion_index_env.value_from.field_ref.field_path
+        == "metadata.annotations['batch.kubernetes.io/job-completion-index']"
+    )
+    assert main_container.args == [
+        "2",
+        f"$({kl._MULTI_NODE_NODE_INDEX_ENV_VAR_NAME})",
+        "tangle-ce-multi-node-123-0.tangle-ce-multi-node-123",
+        "tangle-ce-multi-node-123-0.tangle-ce-multi-node-123,"
+        "tangle-ce-multi-node-123-1.tangle-ce-multi-node-123",
+    ]
+
+    service = kubernetes_apis.core.create_namespaced_service.call_args.kwargs["body"]
+    assert service.spec.cluster_ip == "None"
+    assert service.spec.selector == {"job-name": "tangle-ce-multi-node-123"}
+    serialized = launched.to_dict()
+    launcher_data = serialized[kl.LaunchedKubernetesJob.SERIALIZATION_ROOT_KEY]
+    assert "single_node_job" not in launcher_data
+    assert kl.LaunchedKubernetesJob.from_dict(serialized).to_dict() == serialized
+
+
+def test_dedicated_job_launcher_keeps_indexed_service_behavior(
+    api_client, kubernetes_apis
+):
+    launcher = kl.Local_Kubernetes_UsingHostPathStorage_KubernetesJobLauncher(
+        api_client=api_client
+    )
+
+    launched = launcher.launch_container_task(
+        **_launch_kwargs(),
+        annotations={
+            common_annotations.CONTAINER_EXECUTION_ID_ANNOTATION_KEY: "dedicated-123"
+        },
+    )
+
+    job = kubernetes_apis.batch.create_namespaced_job.call_args.kwargs["body"]
+    assert job.spec.completion_mode == "Indexed"
+    assert job.spec.completions == 1
+    assert job.spec.parallelism == 1
+    assert job.spec.backoff_limit_per_index == 0
+    assert job.spec.max_failed_indexes == 0
+    assert job.spec.template.spec.subdomain == "tangle-ce-dedicated-123"
+    kubernetes_apis.core.create_namespaced_service.assert_called_once()
+    assert (
+        "single_node_job"
+        not in launched.to_dict()[kl.LaunchedKubernetesJob.SERIALIZATION_ROOT_KEY]
+    )
+
+
+def test_legacy_pod_serialization_still_round_trips():
+    pod = k8s_client_lib.V1Pod(
+        metadata=k8s_client_lib.V1ObjectMeta(name="legacy-pod", namespace="default"),
+        spec=k8s_client_lib.V1PodSpec(
+            containers=[k8s_client_lib.V1Container(name="main", image="python:3.12")]
+        ),
+        status=k8s_client_lib.V1PodStatus(phase="Pending"),
+    )
+    launched = kl.LaunchedKubernetesContainer(
+        pod_name="legacy-pod",
+        namespace="default",
+        output_uris={},
+        log_uri="file:///tmp/legacy.log",
+        debug_pod=pod,
+    )
+
+    serialized = launched.to_dict()
+
+    assert kl.LaunchedKubernetesContainer.from_dict(serialized).to_dict() == serialized
+    assert (
+        kl.LaunchedKubernetesContainer.from_dict(serialized["kubernetes"]).to_dict()
+        == serialized
+    )


### PR DESCRIPTION
Adds an opt-in NonIndexed Job mode for single-node tasks while keeping direct Pods as the default and preserving existing Indexed Job behavior for multi-node tasks.

This is a follow-up to #298 and must merge after it. Launcher defaults can select `pod` or `job`, individual tasks can override the single-node mode with an annotation, and multi-node annotations always take precedence.

### Testing

- `uv run --frozen black --check --fast cloud_pipelines_backend/launchers/kubernetes_launchers.py cloud_pipelines_backend/launchers/google_kubernetes_launchers.py tests/test_kubernetes_launchers.py`
- `PYTHONPATH=. uv run --frozen pytest -q tests/test_kubernetes_launchers.py tests/test_skypilot_launchers.py` — 35 passed
- `PYTHONPATH=. uv run --frozen pytest -q` — 449 passed, 13 warnings
- `git diff --check`
