### PR TITLE
Add job_postprocessor hook to Kubernetes Job launchers

### DIFF
--- a/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
@@ -26,6 +26,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: kubernetes_launchers.PodPostProcessor | None = None,
+        job_postprocessor: kubernetes_launchers.JobPostProcessor | None = None,
     ):
         pod_postprocessors = [
             kubernetes_launchers._google_kubernetes_engine_accelerator_pod_postprocessor
@@ -44,6 +45,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesJobLauncher(
             pod_labels=pod_labels,
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,
+            job_postprocessor=job_postprocessor,
             _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
                 gcs_client
             ),
@@ -67,6 +69,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: kubernetes_launchers.PodPostProcessor | None = None,
+        job_postprocessor: kubernetes_launchers.JobPostProcessor | None = None,
     ):
         pod_postprocessors = [
             kubernetes_launchers._google_kubernetes_engine_accelerator_pod_postprocessor
@@ -85,6 +88,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
             pod_labels=pod_labels,
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,
+            job_postprocessor=job_postprocessor,
             _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
                 gcs_client
             ),

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -152,6 +152,12 @@ class PodPostProcessor(typing.Protocol):
     ) -> k8s_client_lib.V1Pod: ...
 
 
+class JobPostProcessor(typing.Protocol):
+    def __call__(
+        self, *, job: k8s_client_lib.V1Job, annotations: dict[str, str] | None = None
+    ) -> k8s_client_lib.V1Job: ...
+
+
 class _KubernetesContainerLauncherBase:
     """Launcher that launches container using Kubernetes"""
 
@@ -999,6 +1005,7 @@ class _KubernetesJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        job_postprocessor: JobPostProcessor | None = None,
         _storage_provider: storage_provider_interfaces.StorageProvider,
         _create_volume_and_volume_mount: typing.Callable[
             [str, str, str, bool],
@@ -1017,6 +1024,7 @@ class _KubernetesJobLauncher(
             pod_postprocessor=pod_postprocessor,
             _create_volume_and_volume_mount=_create_volume_and_volume_mount,
         )
+        self._job_postprocessor = job_postprocessor
 
     def launch_container_task(
         self,
@@ -1242,7 +1250,8 @@ class _KubernetesJobLauncher(
     def _transform_job_before_launching(
         self, *, job: k8s_client_lib.V1Job, annotations: dict[str, str] | None = None
     ) -> k8s_client_lib.V1Job:
-        del annotations
+        if self._job_postprocessor:
+            job = self._job_postprocessor(job=job, annotations=annotations)
         return job
 
     def get_refreshed_launched_container_from_dict(
@@ -1634,6 +1643,7 @@ class _KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        job_postprocessor: JobPostProcessor | None = None,
         _storage_provider: storage_provider_interfaces.StorageProvider,
         _create_volume_and_volume_mount: typing.Callable[
             [str, str, str, bool],
@@ -1660,6 +1670,7 @@ class _KubernetesPodOrJobLauncher(
             pod_labels=pod_labels,
             pod_annotations=pod_annotations,
             pod_postprocessor=pod_postprocessor,
+            job_postprocessor=job_postprocessor,
             _storage_provider=_storage_provider,
             _create_volume_and_volume_mount=_create_volume_and_volume_mount,
         )

--- a/tests/test_kubernetes_launchers.py
+++ b/tests/test_kubernetes_launchers.py
@@ -1,0 +1,83 @@
+"""Tests for cloud_pipelines_backend.launchers.kubernetes_launchers.
+
+These stay offline: they exercise the job_postprocessor plumbing on the base
+launcher classes directly, without a real Kubernetes API client or the GKE
+launchers (which need google.cloud.storage).
+"""
+
+from __future__ import annotations
+
+from kubernetes import client as k8s_client_lib
+
+from cloud_pipelines_backend.launchers import kubernetes_launchers
+
+
+def _job() -> k8s_client_lib.V1Job:
+    return k8s_client_lib.V1Job(
+        spec=k8s_client_lib.V1JobSpec(template=k8s_client_lib.V1PodTemplateSpec())
+    )
+
+
+def _job_launcher_with_postprocessor(
+    job_postprocessor: kubernetes_launchers.JobPostProcessor | None,
+) -> kubernetes_launchers._KubernetesJobLauncher:
+    # Bypass __init__ (needs an api_client / storage provider); we only exercise
+    # the transform hook, which reads self._job_postprocessor.
+    launcher = object.__new__(kubernetes_launchers._KubernetesJobLauncher)
+    launcher._job_postprocessor = job_postprocessor
+    return launcher
+
+
+def test_transform_job_before_launching_applies_job_postprocessor():
+    def set_ttl(*, job: k8s_client_lib.V1Job, annotations=None) -> k8s_client_lib.V1Job:
+        job.spec.ttl_seconds_after_finished = 604800
+        return job
+
+    launcher = _job_launcher_with_postprocessor(set_ttl)
+
+    result = launcher._transform_job_before_launching(job=_job(), annotations={})
+
+    assert result.spec.ttl_seconds_after_finished == 604800
+
+
+def test_transform_job_before_launching_is_noop_without_postprocessor():
+    launcher = _job_launcher_with_postprocessor(None)
+    job = _job()
+
+    result = launcher._transform_job_before_launching(job=job, annotations={})
+
+    assert result is job
+    assert result.spec.ttl_seconds_after_finished is None
+
+
+def test_pod_or_job_launcher_forwards_job_postprocessor(monkeypatch):
+    captured: dict = {}
+
+    class _StubPodLauncher:
+        def __init__(self, **kwargs):
+            pass
+
+    class _StubJobLauncher:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        kubernetes_launchers, "_KubernetesPodLauncher", _StubPodLauncher
+    )
+    monkeypatch.setattr(
+        kubernetes_launchers, "_KubernetesJobLauncher", _StubJobLauncher
+    )
+
+    def job_postprocessor(
+        *, job: k8s_client_lib.V1Job, annotations=None
+    ) -> k8s_client_lib.V1Job:
+        return job
+
+    kubernetes_launchers._KubernetesPodOrJobLauncher(
+        api_client=None,
+        job_postprocessor=job_postprocessor,
+        _storage_provider=None,
+        _create_volume_and_volume_mount=None,
+    )
+
+    assert captured["job_postprocessor"] is job_postprocessor


### PR DESCRIPTION
## Is it safe to deploy?

**Yes — this is fully backward compatible.** `job_postprocessor` is a new keyword-only parameter defaulting to `None`, so every existing launcher call site is unaffected and the Job-transform hook stays a no-op until a caller explicitly opts in.

## What

Adds a `job_postprocessor` hook to the Kubernetes **Job** launchers, symmetric to the existing `pod_postprocessor`. It lets a caller transform the `V1Job` object right before it's created, threaded through `_KubernetesJobLauncher`, `_KubernetesPodOrJobLauncher`, and both `GoogleKubernetesEngine_UsingGoogleCloudStorage_*` launchers.

```python
class JobPostProcessor(typing.Protocol):
    def __call__(
        self, *, job: k8s_client_lib.V1Job, annotations: dict[str, str] | None = None
    ) -> k8s_client_lib.V1Job: ...
```

The default `_transform_job_before_launching` now applies the injected `job_postprocessor` when one is set, and is otherwise the same no-op it was before.

## Why

The launchers already let callers customize the **Pod** (via `pod_postprocessor`), and for multi-node runs that Pod becomes the Job's pod *template* — so pod-level changes already reach Job pods. But there was **no way to set fields on the `V1Job` itself** without editing this repo:

- `_transform_job_before_launching` was a no-op override hook living on `_KubernetesJobLauncher`, but the class callers actually build is `_KubernetesPodOrJobLauncher`, which constructs a **private inner** `_KubernetesJobLauncher` with no hook threaded through. So subclassing the public launcher can't reach it.

The concrete need: a downstream (Tangle/oasis) execution cluster with **no Kueue and a janitor that holds no `batch/jobs` permission**, so finished **Job objects** are never reaped. Stamping `spec.ttlSecondsAfterFinished` lets Kubernetes' native TTL-after-finished controller clean them up — but that field is on the Job, not the pod template, so `pod_postprocessor` can't set it. With this hook the caller does:

```python
def _set_job_ttl(*, job, annotations=None):
    if job.spec.ttl_seconds_after_finished is None:
        job.spec.ttl_seconds_after_finished = 7 * 24 * 60 * 60
    return job

launcher = GoogleKubernetesEngine_..._KubernetesPodOrJobLauncher(
    ..., job_postprocessor=_set_job_ttl,
)
```

## System impact

- **No behavior change when unused.** `job_postprocessor` defaults to `None`; the transform hook stays a no-op, so every existing launch path is byte-identical. New keyword-only param with a default → no call-site is required to change.
- Applies only to the Job path (multi-node runs); the Pod path is untouched.

## Before / after

- **Before:** the only way to influence the launched Job was to fork/subclass the inner `_KubernetesJobLauncher`, which public callers don't instantiate → effectively not extensible.
- **After:** callers pass a `job_postprocessor` the same way they already pass `pod_postprocessor`.

## Tests

`tests/test_kubernetes_launchers.py` (new, offline — no live K8s API or GCS):
- `_transform_job_before_launching` applies the `job_postprocessor` when set;
- it's a no-op (returns the same Job unchanged) when unset;
- `_KubernetesPodOrJobLauncher` forwards `job_postprocessor` to its inner Job launcher.

All pass; `black`-formatted.

