### PR TITLE
feat(orchestrator): count vanished workloads

### DIFF
--- a/cloud_pipelines_backend/instrumentation/metrics.py
+++ b/cloud_pipelines_backend/instrumentation/metrics.py
@@ -55,6 +55,15 @@ execution_system_errors = orchestrator_meter.create_counter(
     unit=MetricUnit.ERRORS,
 )
 
+container_execution_missing_workloads = orchestrator_meter.create_counter(
+    name="container_execution.missing_workloads",
+    description=(
+        "Number of container executions that failed because their workload"
+        " disappeared before it completed (e.g. the pod was deleted)"
+    ),
+    unit=MetricUnit.ERRORS,
+)
+
 execution_status_transition_duration = orchestrator_meter.create_histogram(
     name="execution.status_transition.duration",
     description="Duration an execution spent in a status before transitioning to the next status",

--- a/cloud_pipelines_backend/launchers/interfaces.py
+++ b/cloud_pipelines_backend/launchers/interfaces.py
@@ -37,6 +37,16 @@ class LauncherError(RuntimeError):
         self.is_retriable = is_retriable
 
 
+class LaunchedContainerNotFoundError(LauncherError):
+    """The launched container no longer exists (e.g. its pod was deleted).
+
+    A definitive, non-retriable failure: re-reading cannot bring it back. The
+    launcher raises this so the orchestrator can tell "the workload is gone"
+    apart from "we could not reach the platform" without inspecting platform
+    error codes itself.
+    """
+
+
 @dataclasses.dataclass(kw_only=True)
 class InputArgument:
     total_size: int

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import http
 import json
 import logging
 import os
@@ -1867,10 +1868,12 @@ def _launcher_error_from_api_exception(
 ) -> interfaces.LauncherError:
     """Translate a Kubernetes API error into a launcher error.
 
-    A 5xx is retriable (the API server broke or shed load); any other status is
-    a definitive failure.
+    A 404 means the workload is gone; a 5xx is retriable (the API server broke
+    or shed load); any other status is a definitive failure.
     """
     status = exception.status
+    if status == http.HTTPStatus.NOT_FOUND:
+        return interfaces.LaunchedContainerNotFoundError(f"{message}: {exception!r}")
     is_retriable = isinstance(status, int) and 500 <= status < 600
     return interfaces.LauncherError(
         f"{message}: {exception!r}", is_retriable=is_retriable

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -224,6 +224,16 @@ class OrchestratorService_Sql:
                         isinstance(ex, launcher_interfaces.LauncherError)
                         and ex.is_retriable
                     )
+                    if isinstance(
+                        ex, launcher_interfaces.LaunchedContainerNotFoundError
+                    ):
+                        app_metrics.container_execution_missing_workloads.add(
+                            1,
+                            attributes={
+                                "status": running_container_execution.status.value
+                            },
+                        )
+
                     error_count = (
                         self._container_execution_refresh_error_counts.get(
                             running_container_execution.id, 0

--- a/tests/test_container_execution_refresh_retries.py
+++ b/tests/test_container_execution_refresh_retries.py
@@ -24,6 +24,10 @@ def _non_retriable_error() -> launcher_interfaces.LauncherError:
     return launcher_interfaces.LauncherError("Something went definitively wrong")
 
 
+def _missing_workload_error() -> launcher_interfaces.LaunchedContainerNotFoundError:
+    return launcher_interfaces.LaunchedContainerNotFoundError("The workload is gone")
+
+
 def _create_session_factory() -> Callable[[], orm.Session]:
     db_engine = database_ops.create_db_engine_and_migrate_db(database_uri="sqlite://")
     return lambda: orm.Session(bind=db_engine)
@@ -152,6 +156,30 @@ class TestContainerExecutionRefreshRetries:
             session=session_factory()
         )
 
+        assert _only_status(session_factory) == (
+            bts.ContainerExecutionStatus.SYSTEM_ERROR
+        )
+
+    def test_missing_workload_is_counted_and_terminalizes(self) -> None:
+        session_factory = _create_launched_container_executions()
+        orchestrator = _make_orchestrator(
+            session_factory,
+            mock.MagicMock(side_effect=_missing_workload_error()),
+            max_failures=3,
+        )
+
+        with mock.patch.object(
+            orchestrator_sql.app_metrics, "container_execution_missing_workloads"
+        ) as missing_workloads:
+            orchestrator.internal_process_running_executions_queue(
+                session=session_factory()
+            )
+
+        missing_workloads.add.assert_called_once()
+        args, kwargs = missing_workloads.add.call_args
+        assert args == (1,)
+        assert isinstance(kwargs["attributes"]["status"], str)
+        assert kwargs["attributes"]["status"]
         assert _only_status(session_factory) == (
             bts.ContainerExecutionStatus.SYSTEM_ERROR
         )

--- a/tests/test_kubernetes_launcher_error_classification.py
+++ b/tests/test_kubernetes_launcher_error_classification.py
@@ -24,10 +24,11 @@ class TestLauncherErrorFromApiException:
         )
         assert error.is_retriable
 
-    def test_not_found_is_not_retriable(self) -> None:
+    def test_not_found_is_a_missing_workload_error(self) -> None:
         error = kubernetes_launchers._launcher_error_from_api_exception(
             _api_exception(404), message="Failed to refresh pod status"
         )
+        assert isinstance(error, interfaces.LaunchedContainerNotFoundError)
         assert not error.is_retriable
 
     def test_client_error_is_not_retriable(self) -> None:


### PR DESCRIPTION
## What

Adds one counter, `execution.missing_workloads`, incremented when refreshing a running container fails because the **workload no longer exists** — it is gone, not merely unobservable.

The counter is labelled with the **status the container was in when it vanished** (`RUNNING` vs `PENDING`), since workloads killed mid-run and workloads that never started usually have different root causes.

Consistent with the launcher/orchestrator boundary, the Kubernetes launcher maps a **404** to a typed `LaunchedContainerNotFoundError`; the orchestrator counts that typed error without inspecting HTTP status codes.

## Why

In one recent 17h production window, vanished workloads accounted for **162 of 255** orchestrator `SYSTEM_ERROR`s. This makes that slice measurable.

## Scope

Observability only. A not-found error is non-retriable, so the execution still terminalizes as `SYSTEM_ERROR` exactly as before — **no change to verdicts or pipeline semantics**.
