### PR TITLE
docs: keep platform specifics out of the generic core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Agent notes
+
+## Keep platform specifics out of the generic core
+
+The orchestrator (`cloud_pipelines_backend/orchestrator_sql.py`) and the launcher
+interface (`cloud_pipelines_backend/launchers/interfaces.py`) are
+platform-agnostic. Do not put Kubernetes, HTTP, or cloud-SDK details in them.
+
+Platform logic belongs in the concrete launcher (e.g. `kubernetes_launchers.py`),
+which turns backend failures into typed `LauncherError`s. The orchestrator acts
+on the typed error, never on a raw status code.


### PR DESCRIPTION
## What

Adds a repo-root `CLAUDE.md` documenting the architectural rule this stack is built around: **the generic core stays platform-agnostic.**

- The orchestrator (`orchestrator_sql.py`) and the launcher interface (`launchers/interfaces.py`) must not inspect HTTP status codes, Kubernetes exceptions, or any other backend detail.
- Platform-specific classification lives in the concrete launcher (e.g. `kubernetes_launchers.py`), which translates backend failures into typed, platform-neutral `LauncherError`s.
- The orchestrator acts only on the typed result (`isinstance(...)`, `err.is_retriable`).

## Why

The rest of this stack (#312, #313) moved HTTP/Kubernetes classification out of the orchestrator and into the launcher. This file captures that boundary so future changes — by humans or coding agents — don't reintroduce platform specifics into the generic core.

## Impact

Docs only. No code or runtime behaviour changes.
