### PR TITLE
fix(kubernetes): hold task pods until their terminal status is observed

### DIFF
--- a/cloud_pipelines_backend/launchers/interfaces.py
+++ b/cloud_pipelines_backend/launchers/interfaces.py
@@ -137,6 +137,21 @@ class LaunchedContainer(abc.ABC):
     def terminate(self) -> None:
         raise NotImplementedError()
 
+    def release(self) -> bool:
+        """Releases any hold the orchestrator has on the launched container.
+
+        A launcher may keep the underlying workload object alive after the
+        container has finished, so that its terminal status, exit code and logs
+        can still be observed (the Kubernetes pod launcher does this with a
+        finalizer). Calling `release` says "I have everything I need" and lets
+        the cluster reclaim the object.
+
+        Returns True when a hold was actually released. Launchers that hold
+        nothing return False, which is the default, so callers can call this
+        unconditionally.
+        """
+        return False
+
 
 # @dataclasses.dataclass
 # class ContainerExecutionResult:

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -35,6 +35,97 @@ _MAIN_CONTAINER_NAME = "main"
 # Kubernetes annotation keys. (Has strict naming policy. Single slash only etc.)
 _CLOUD_PIPELINES_KUBERNETES_ANNOTATION_KEY = "cloud-pipelines.net"
 _KUBERNETES_LAUNCHER_ANNOTATION_KEY = "cloud-pipelines.net/launchers.kubernetes"
+# Finalizer that keeps a task pod's API object alive after the container has
+# finished, until the orchestrator has observed its terminal status. While it is
+# present a delete only stamps `deletionTimestamp`: the object stays readable in
+# `Terminating` instead of disappearing mid-poll. See `LaunchedContainer.release`.
+_STATUS_OBSERVED_FINALIZER = "cloud-pipelines.net/status-observed"
+# Finalizers are not selectable, so the hold is mirrored in a label to make held
+# pods findable by `release_abandoned_finalizer_holds`.
+_STATUS_OBSERVED_FINALIZER_LABEL_KEY = "cloud-pipelines.net/held-for-status"
+# Opt-in, because a hold that is never released is worse than a pod that is
+# collected too early. Set on the launcher, or through this environment variable
+# for deployments that construct the launcher without threading the argument.
+_HOLD_PODS_ENV_VAR = "CLOUD_PIPELINES_HOLD_PODS_UNTIL_STATUS_OBSERVED"
+_DEFAULT_MAX_FINALIZER_HOLD = datetime.timedelta(minutes=10)
+
+
+def _env_flag(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _add_status_observed_finalizer(pod: k8s_client_lib.V1Pod) -> None:
+    """Marks a pod as held until the orchestrator observes its terminal status."""
+    metadata = pod.metadata
+    finalizers = list(metadata.finalizers or [])
+    if _STATUS_OBSERVED_FINALIZER not in finalizers:
+        finalizers.append(_STATUS_OBSERVED_FINALIZER)
+    metadata.finalizers = finalizers
+    metadata.labels = (metadata.labels or {}) | {
+        _STATUS_OBSERVED_FINALIZER_LABEL_KEY: "true"
+    }
+
+
+def _remove_status_observed_finalizer(
+    *,
+    core_api_client: k8s_client_lib.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    request_timeout: int | tuple[int, int] = 10,
+    pod: k8s_client_lib.V1Pod | None = None,
+    max_attempts: int = 3,
+) -> bool:
+    """Removes the hold finalizer from a pod. Returns True if one was removed.
+
+    Idempotent: a pod that was never held, or is already gone, is not an error.
+    Removing the finalizer never deletes anything by itself; it only stops
+    blocking a deletion that someone else has already requested or will request.
+    """
+    for attempt in range(1, max_attempts + 1):
+        if pod is None:
+            try:
+                pod = core_api_client.read_namespaced_pod(
+                    name=pod_name,
+                    namespace=namespace,
+                    _request_timeout=request_timeout,
+                )
+            except kubernetes.client.exceptions.ApiException as ex:
+                if ex.status == 404:
+                    return False
+                raise
+        current_finalizers = list(
+            (pod.metadata.finalizers if pod.metadata else None) or []
+        )
+        if _STATUS_OBSERVED_FINALIZER not in current_finalizers:
+            return False
+        remaining = [f for f in current_finalizers if f != _STATUS_OBSERVED_FINALIZER]
+        # JSON Patch: a list body makes the Kubernetes client select
+        # `application/json-patch+json`. A strategic merge patch cannot express
+        # this, because `metadata.finalizers` has merge semantics and can only
+        # gain entries that way. The `test` op makes the removal atomic against
+        # a concurrent writer.
+        patch = [
+            {"op": "test", "path": "/metadata/finalizers", "value": current_finalizers},
+            {"op": "replace", "path": "/metadata/finalizers", "value": remaining},
+        ]
+        try:
+            core_api_client.patch_namespaced_pod(
+                name=pod_name,
+                namespace=namespace,
+                body=patch,
+                _request_timeout=request_timeout,
+            )
+            _logger.info(f"Released pod {pod_name} in namespace {namespace}.")
+            return True
+        except kubernetes.client.exceptions.ApiException as ex:
+            if ex.status == 404:
+                return False
+            if ex.status in (409, 422) and attempt < max_attempts:
+                # Someone else changed the finalizer list. Re-read and retry.
+                pod = None
+                continue
+            raise
+    return False
 # ComponentSpec annotation keys
 RESOURCES_CPU_ANNOTATION_KEY = "cloud-pipelines.net/launchers/generic/resources.cpu"
 RESOURCES_MEMORY_ANNOTATION_KEY = (
@@ -166,6 +257,7 @@ class _KubernetesContainerLauncherBase:
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        hold_pods_until_status_observed: bool | None = None,
         _storage_provider: storage_provider_interfaces.StorageProvider,
         _create_volume_and_volume_mount: typing.Callable[
             [str, str, str, bool],
@@ -184,6 +276,13 @@ class _KubernetesContainerLauncherBase:
             _KUBERNETES_LAUNCHER_ANNOTATION_KEY: "true",
         } | (pod_annotations or {})
         self._pod_postprocessor = pod_postprocessor
+        # Left to the environment when not passed explicitly, so a deployment can
+        # turn the hold on without every launcher subclass forwarding the flag.
+        self._hold_pods_until_status_observed = (
+            _env_flag(_HOLD_PODS_ENV_VAR)
+            if hold_pods_until_status_observed is None
+            else hold_pods_until_status_observed
+        )
         self._create_volume_and_volume_mount = _create_volume_and_volume_mount
 
         try:
@@ -562,6 +661,15 @@ class _KubernetesPodLauncher(
         if self._pod_postprocessor:
             pod = self._pod_postprocessor(pod=pod, annotations=annotations)
 
+        # Hold the pod object until its terminal status has been observed.
+        # Applied after the post-processor so a post-processor cannot drop it,
+        # and before creation so the pod is never unprotected. Deliberately only
+        # on pod-launched containers: a Job outlives its pods, so the Job
+        # launcher does not need this, and must not have it, since the Job
+        # controller's own pod cleanup would wedge on the finalizer.
+        if self._hold_pods_until_status_observed:
+            _add_status_observed_finalizer(pod)
+
         core_api_client = k8s_client_lib.CoreV1Api(api_client=self._api_client)
         try:
             created_pod: k8s_client_lib.V1Pod = core_api_client.create_namespaced_pod(
@@ -588,6 +696,69 @@ class _KubernetesPodLauncher(
             launcher=self,
         )
         return launched_kubernetes_container
+
+    def release_abandoned_finalizer_holds(
+        self,
+        *,
+        max_hold: datetime.timedelta = _DEFAULT_MAX_FINALIZER_HOLD,
+        namespace: str | None = None,
+    ) -> int:
+        """Force-releases held pods whose deletion has been pending too long.
+
+        Every hold needs a guaranteed release. Without this, a pod nothing polls
+        any more (the orchestrator restarted, its execution row is gone, it was
+        terminalized by a path that could not release) would sit in
+        `Terminating` for ever, holding etcd space and namespace pod quota and
+        consuming the cluster's pod-GC budget. This bounds the worst case: no
+        pod is held longer than `max_hold` past its deletion request, whatever
+        the orchestrator does.
+
+        Cluster-wide by default, because a pod post-processor may place pods in
+        a namespace other than the launcher's own.
+        """
+        core_api_client = k8s_client_lib.CoreV1Api(api_client=self._api_client)
+        label_selector = f"{_STATUS_OBSERVED_FINALIZER_LABEL_KEY}=true"
+        if namespace:
+            pod_list = core_api_client.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=label_selector,
+                _request_timeout=self._request_timeout,
+            )
+        else:
+            pod_list = core_api_client.list_pod_for_all_namespaces(
+                label_selector=label_selector,
+                _request_timeout=self._request_timeout,
+            )
+        now = datetime.datetime.now(datetime.timezone.utc)
+        released = 0
+        for pod in pod_list.items or []:
+            metadata = pod.metadata
+            if not metadata or not metadata.deletion_timestamp:
+                # Not deleted, so the hold is not blocking anything.
+                continue
+            if _STATUS_OBSERVED_FINALIZER not in (metadata.finalizers or []):
+                continue
+            held_for = now - metadata.deletion_timestamp
+            if held_for < max_hold:
+                continue
+            _logger.warning(
+                f"Force-releasing pod {metadata.name} in namespace"
+                f" {metadata.namespace}: its deletion has been held for"
+                f" {held_for} (max {max_hold}). Its execution will not get to"
+                " see the pod's terminal status."
+            )
+            try:
+                if _remove_status_observed_finalizer(
+                    core_api_client=core_api_client,
+                    pod_name=metadata.name,
+                    namespace=metadata.namespace,
+                    request_timeout=self._request_timeout,
+                    pod=pod,
+                ):
+                    released += 1
+            except Exception:
+                _logger.exception(f"Failed to force-release pod {metadata.name}.")
+        return released
 
     def get_refreshed_launched_container_from_dict(
         self, launched_container_dict: dict
@@ -981,6 +1152,22 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
             grace_period_seconds=10,
         )
         _logger.info(f"Terminated pod {self._pod_name} in namespace {self._namespace}")
+
+    def release(self) -> bool:
+        """Removes the hold finalizer so Kubernetes may delete the pod.
+
+        Call this once the container's terminal status, exit code and logs have
+        been recorded, and on every other path that terminalizes an execution:
+        anything that is never polled again must not stay held.
+        """
+        launcher = self._get_launcher()
+        core_api_client = k8s_client_lib.CoreV1Api(api_client=launcher._api_client)
+        return _remove_status_observed_finalizer(
+            core_api_client=core_api_client,
+            pod_name=self._pod_name,
+            namespace=self._namespace,
+            request_timeout=launcher._request_timeout,
+        )
 
 
 class _KubernetesJobLauncher(
@@ -1634,6 +1821,7 @@ class _KubernetesPodOrJobLauncher(
         pod_labels: dict[str, str] | None = None,
         pod_annotations: dict[str, str] | None = None,
         pod_postprocessor: PodPostProcessor | None = None,
+        hold_pods_until_status_observed: bool | None = None,
         _storage_provider: storage_provider_interfaces.StorageProvider,
         _create_volume_and_volume_mount: typing.Callable[
             [str, str, str, bool],
@@ -1649,9 +1837,13 @@ class _KubernetesPodOrJobLauncher(
             pod_labels=pod_labels,
             pod_annotations=pod_annotations,
             pod_postprocessor=pod_postprocessor,
+            hold_pods_until_status_observed=hold_pods_until_status_observed,
             _storage_provider=_storage_provider,
             _create_volume_and_volume_mount=_create_volume_and_volume_mount,
         )
+        # Note: the hold is deliberately not passed to the Job launcher. A Job
+        # outlives its pods, so its status survives pod collection, and a
+        # finalizer on Job-owned pods would wedge the Job controller's cleanup.
         self._job_launcher = _KubernetesJobLauncher(
             api_client=api_client,
             namespace=namespace,
@@ -1666,6 +1858,19 @@ class _KubernetesPodOrJobLauncher(
         # This might help cross-cluster launchers identify this launcher via teh server address.
         self._api_client = api_client
         self._storage_provider = _storage_provider
+
+    def release_abandoned_finalizer_holds(
+        self,
+        *,
+        max_hold: datetime.timedelta = _DEFAULT_MAX_FINALIZER_HOLD,
+        namespace: str | None = None,
+    ) -> int:
+        """Sweeps abandoned holds. This launcher composes rather than inherits,
+        so the sweep has to be forwarded explicitly, or the orchestrator would
+        silently find no sweeper on the launcher production actually uses."""
+        return self._pod_launcher.release_abandoned_finalizer_holds(
+            max_hold=max_hold, namespace=namespace
+        )
 
     def launch_container_task(
         self,

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -33,6 +33,36 @@ DYNAMIC_DATA_SECRET_KEY = "secret"
 DYNAMIC_DATA_SECRET_NAME_KEY = "name"
 
 
+# Statuses from which an execution is never polled again. Anything that reaches
+# one of these must release its workload hold, or the workload object is held
+# for ever (see `LaunchedContainer.release`).
+_TERMINAL_CONTAINER_EXECUTION_STATUSES = frozenset(
+    {
+        bts.ContainerExecutionStatus.SUCCEEDED,
+        bts.ContainerExecutionStatus.FAILED,
+        bts.ContainerExecutionStatus.SYSTEM_ERROR,
+        bts.ContainerExecutionStatus.CANCELLED,
+    }
+)
+
+
+def _release_launched_container(
+    launched_container: launcher_interfaces.LaunchedContainer | None,
+) -> None:
+    """Tells the launcher we are done with a container we will not poll again.
+
+    Best-effort by construction: the execution's outcome is already recorded and
+    committed, so a failure to release must never change it. A missed release is
+    picked up later by the launcher's own sweep.
+    """
+    if launched_container is None:
+        return
+    try:
+        launched_container.release()
+    except Exception as ex:
+        _logger.warning(f"Failed to release the launched container: {ex!r}")
+
+
 class OrchestratorError(RuntimeError):
     pass
 
@@ -50,6 +80,10 @@ class OrchestratorService_Sql:
         default_task_annotations: dict[str, Any] | None = None,
         sleep_seconds_between_queue_sweeps: float = 1.0,
         output_data_purge_duration: datetime.timedelta = None,
+        finalizer_hold_max_duration: datetime.timedelta = datetime.timedelta(
+            minutes=10
+        ),
+        finalizer_sweep_interval: datetime.timedelta = datetime.timedelta(minutes=1),
         *,
         # Internal/experimental:
         _max_queue_batch_size: int = 1,
@@ -65,6 +99,10 @@ class OrchestratorService_Sql:
         self._queued_executions_queue_idle = False
         self._running_executions_queue_idle = False
         self._output_data_purge_duration = output_data_purge_duration
+        # Backstop for workload holds that no execution will release itself.
+        self._finalizer_hold_max_duration = finalizer_hold_max_duration
+        self._finalizer_sweep_interval = finalizer_sweep_interval
+        self._last_finalizer_sweep_at: float | None = None
 
         self._max_queue_batch_size = _max_queue_batch_size
         self._max_queue_batch_duration = _max_queue_batch_duration
@@ -160,7 +198,45 @@ class OrchestratorService_Sql:
                 _logger.debug("No queued executions found")
             return False
 
+    def _deserialize_launched_container_or_none(
+        self, launcher_data: Any
+    ) -> launcher_interfaces.LaunchedContainer | None:
+        if not launcher_data:
+            return None
+        try:
+            return self._launcher.deserialize_launched_container_from_dict(
+                launcher_data
+            )
+        except Exception as ex:
+            _logger.warning(
+                f"Could not deserialize the launched container to release it: {ex!r}"
+            )
+            return None
+
+    def _maybe_release_abandoned_holds(self) -> None:
+        """Periodically clears workload holds that nothing else will release."""
+        release_holds = getattr(
+            self._launcher, "release_abandoned_finalizer_holds", None
+        )
+        if release_holds is None:
+            return
+        now = time.monotonic()
+        if (
+            self._last_finalizer_sweep_at is not None
+            and now - self._last_finalizer_sweep_at
+            < self._finalizer_sweep_interval.total_seconds()
+        ):
+            return
+        self._last_finalizer_sweep_at = now
+        try:
+            released = release_holds(max_hold=self._finalizer_hold_max_duration)
+            if released:
+                _logger.warning(f"Force-released {released} abandoned workload holds.")
+        except Exception as ex:
+            _logger.warning(f"Could not sweep abandoned workload holds: {ex!r}")
+
     def internal_process_running_executions_queue(self, session: orm.Session):
+        self._maybe_release_abandoned_holds()
         # Select only the ID to avoid loading large JSON columns into the sort buffer.
         id_query = (
             sql.select(bts.ContainerExecution.id)
@@ -230,6 +306,14 @@ class OrchestratorService_Sql:
                             session=session, execution=execution_node
                         )
                     session.commit()
+
+                    # This execution is terminal and will never be polled again,
+                    # so drop any hold we have on its workload.
+                    _release_launched_container(
+                        self._deserialize_launched_container_or_none(
+                            running_container_execution.launcher_data
+                        )
+                    )
                 finally:
                     duration_ms = (time.monotonic_ns() - start_timestamp) / 1_000_000
                     _logger.info(
@@ -789,6 +873,11 @@ class OrchestratorService_Sql:
                 # Requesting container termination.
                 # Termination might not happen immediately (e.g. Kubernetes has grace period).
                 launched_container.terminate()
+                # We already have the logs and this execution is about to become
+                # CANCELLED, which stops it being polled. Release the hold now:
+                # without this, every cancellation leaves a pod wedged in
+                # `Terminating` with nobody left to free it.
+                _release_launched_container(launched_container)
                 container_execution.ended_at = _get_current_time()
                 # We need to mark the execution as CANCELLED otherwise orchestrator will continue polling it.
                 container_execution.status = bts.ContainerExecutionStatus.CANCELLED
@@ -1027,6 +1116,11 @@ class OrchestratorService_Sql:
                 f"Unexpected running container status: {new_status=}, {launched_container=}"
             )
         session.commit()
+
+        if container_execution.status in _TERMINAL_CONTAINER_EXECUTION_STATUSES:
+            # Status, exit code, logs and output artifacts are recorded and
+            # committed, so the workload object is no longer needed.
+            _release_launched_container(reloaded_launched_container)
 
 
 def _get_direct_downstream_executions(

--- a/tests/test_pod_finalizer_release.py
+++ b/tests/test_pod_finalizer_release.py
@@ -1,0 +1,396 @@
+"""Tests for the pod hold that keeps a finished pod readable until we've read it.
+
+Kubernetes clusters garbage-collect terminated pods on their own schedule, and
+that schedule is not ours to set: a pod can be removed within seconds of its
+container finishing, before the orchestrator's next poll observes the terminal
+status, exit code and logs. The pod launcher can opt into holding the pod object
+with a finalizer, which turns that race into a handshake.
+
+The dangerous half is the release, not the hold: a pod that is held and never
+released stays in ``Terminating`` for ever. These tests pin both halves, and in
+particular that every path which terminalizes an execution releases the hold,
+including cancellation, which returns early and is never polled again.
+"""
+
+import datetime
+from typing import Callable
+from unittest import mock
+
+import pytest
+from kubernetes import client as k8s_client_lib
+from kubernetes.client import exceptions as k8s_exceptions
+from sqlalchemy import orm
+from sqlalchemy import sql
+
+from cloud_pipelines_backend import api_server_sql
+from cloud_pipelines_backend import backend_types_sql as bts
+from cloud_pipelines_backend import component_structures as structures
+from cloud_pipelines_backend import database_ops
+from cloud_pipelines_backend import orchestrator_sql
+from cloud_pipelines_backend.launchers import interfaces as launcher_interfaces
+from cloud_pipelines_backend.launchers import kubernetes_launchers
+
+_FINALIZER = kubernetes_launchers._STATUS_OBSERVED_FINALIZER
+_LABEL_KEY = kubernetes_launchers._STATUS_OBSERVED_FINALIZER_LABEL_KEY
+_LAUNCHER_DATA = {"pod_name": "task-1-abcde", "namespace": "kueue-jobs"}
+
+
+def _api_exception(status: int) -> k8s_exceptions.ApiException:
+    return k8s_exceptions.ApiException(status=status, reason="test")
+
+
+def _pod(
+    *,
+    name: str = "task-1-abcde",
+    namespace: str = "kueue-jobs",
+    finalizers: list[str] | None = None,
+    deletion_timestamp=None,
+) -> k8s_client_lib.V1Pod:
+    return k8s_client_lib.V1Pod(
+        metadata=k8s_client_lib.V1ObjectMeta(
+            name=name,
+            namespace=namespace,
+            finalizers=finalizers,
+            deletion_timestamp=deletion_timestamp,
+        )
+    )
+
+
+class TestAddingTheHold:
+    def test_adds_the_finalizer_and_a_matching_label(self) -> None:
+        pod = _pod()
+        kubernetes_launchers._add_status_observed_finalizer(pod)
+        assert pod.metadata.finalizers == [_FINALIZER]
+        # Finalizers are not selectable, so the sweeper needs the label.
+        assert pod.metadata.labels[_LABEL_KEY] == "true"
+
+    def test_is_idempotent_and_keeps_other_finalizers(self) -> None:
+        pod = _pod(finalizers=["someone.else/finalizer"])
+        kubernetes_launchers._add_status_observed_finalizer(pod)
+        kubernetes_launchers._add_status_observed_finalizer(pod)
+        assert pod.metadata.finalizers == ["someone.else/finalizer", _FINALIZER]
+
+    def test_the_hold_is_off_unless_asked_for(self) -> None:
+        # A hold that is never released is worse than a pod collected too early,
+        # so opting in is deliberate.
+        with mock.patch.dict("os.environ", {}, clear=True):
+            assert kubernetes_launchers._env_flag(
+                kubernetes_launchers._HOLD_PODS_ENV_VAR
+            ) is False
+        with mock.patch.dict(
+            "os.environ",
+            {kubernetes_launchers._HOLD_PODS_ENV_VAR: "true"},
+        ):
+            assert kubernetes_launchers._env_flag(
+                kubernetes_launchers._HOLD_PODS_ENV_VAR
+            ) is True
+
+
+class TestRemovingTheHold:
+    def test_removes_the_finalizer_with_a_json_patch(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.return_value = _pod(
+            finalizers=["someone.else/finalizer", _FINALIZER]
+        )
+
+        released = kubernetes_launchers._remove_status_observed_finalizer(
+            core_api_client=api, pod_name="task-1-abcde", namespace="kueue-jobs"
+        )
+
+        assert released is True
+        patch_body = api.patch_namespaced_pod.call_args.kwargs["body"]
+        # A list body is what makes the Kubernetes client send a JSON Patch. A
+        # strategic merge patch would merge the list and never remove anything.
+        assert isinstance(patch_body, list)
+        assert patch_body == [
+            {
+                "op": "test",
+                "path": "/metadata/finalizers",
+                "value": ["someone.else/finalizer", _FINALIZER],
+            },
+            {
+                "op": "replace",
+                "path": "/metadata/finalizers",
+                "value": ["someone.else/finalizer"],
+            },
+        ]
+
+    def test_does_nothing_when_the_pod_is_not_held(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.return_value = _pod(finalizers=None)
+
+        released = kubernetes_launchers._remove_status_observed_finalizer(
+            core_api_client=api, pod_name="task-1-abcde", namespace="kueue-jobs"
+        )
+
+        assert released is False
+        api.patch_namespaced_pod.assert_not_called()
+
+    def test_a_pod_that_is_already_gone_is_not_an_error(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.side_effect = _api_exception(404)
+
+        assert (
+            kubernetes_launchers._remove_status_observed_finalizer(
+                core_api_client=api, pod_name="task-1-abcde", namespace="kueue-jobs"
+            )
+            is False
+        )
+
+    def test_retries_when_another_writer_changed_the_finalizers(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.return_value = _pod(finalizers=[_FINALIZER])
+        # The `test` op fails when the list moved under us; re-read and retry.
+        api.patch_namespaced_pod.side_effect = [_api_exception(422), None]
+
+        released = kubernetes_launchers._remove_status_observed_finalizer(
+            core_api_client=api, pod_name="task-1-abcde", namespace="kueue-jobs"
+        )
+
+        assert released is True
+        assert api.patch_namespaced_pod.call_count == 2
+        assert api.read_namespaced_pod.call_count == 2
+
+    def test_a_real_api_error_is_not_swallowed_here(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.return_value = _pod(finalizers=[_FINALIZER])
+        api.patch_namespaced_pod.side_effect = _api_exception(500)
+
+        with pytest.raises(k8s_exceptions.ApiException):
+            kubernetes_launchers._remove_status_observed_finalizer(
+                core_api_client=api, pod_name="task-1-abcde", namespace="kueue-jobs"
+            )
+
+    def test_launched_container_release_uses_its_own_pod_coordinates(self) -> None:
+        api = mock.MagicMock()
+        api.read_namespaced_pod.return_value = _pod(finalizers=[_FINALIZER])
+        launcher = mock.MagicMock(_api_client=mock.MagicMock(), _request_timeout=10)
+        launched = kubernetes_launchers.LaunchedKubernetesContainer(
+            pod_name="task-1-abcde",
+            namespace="kueue-jobs",
+            output_uris={},
+            log_uri="file:///tmp/log",
+            debug_pod=_pod(),
+            launcher=launcher,
+        )
+
+        with mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "CoreV1Api", return_value=api
+        ):
+            assert launched.release() is True
+
+        assert api.patch_namespaced_pod.call_args.kwargs["name"] == "task-1-abcde"
+        assert api.patch_namespaced_pod.call_args.kwargs["namespace"] == "kueue-jobs"
+
+
+class TestSweepingAbandonedHolds:
+    def _sweep(self, pods: list[k8s_client_lib.V1Pod], api: mock.MagicMock) -> int:
+        api.list_pod_for_all_namespaces.return_value = k8s_client_lib.V1PodList(
+            items=pods
+        )
+        fake_launcher = mock.MagicMock(
+            _api_client=mock.MagicMock(), _request_timeout=10
+        )
+        with mock.patch.object(
+            kubernetes_launchers.k8s_client_lib, "CoreV1Api", return_value=api
+        ):
+            return kubernetes_launchers._KubernetesPodLauncher.release_abandoned_finalizer_holds(
+                fake_launcher, max_hold=datetime.timedelta(minutes=10)
+            )
+
+    def test_releases_only_holds_older_than_the_cap(self) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        stale = _pod(
+            name="stale",
+            finalizers=[_FINALIZER],
+            deletion_timestamp=now - datetime.timedelta(minutes=30),
+        )
+        recent = _pod(
+            name="recent",
+            finalizers=[_FINALIZER],
+            deletion_timestamp=now - datetime.timedelta(minutes=1),
+        )
+        # Held, but nobody has asked for it to be deleted, so it blocks nothing.
+        not_deleted = _pod(name="alive", finalizers=[_FINALIZER])
+        api = mock.MagicMock()
+
+        released = self._sweep([stale, recent, not_deleted], api)
+
+        assert released == 1
+        patched_names = {
+            call.kwargs["name"] for call in api.patch_namespaced_pod.call_args_list
+        }
+        assert patched_names == {"stale"}
+
+    def test_one_stuck_pod_does_not_stop_the_sweep(self) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        pods = [
+            _pod(
+                name=name,
+                finalizers=[_FINALIZER],
+                deletion_timestamp=now - datetime.timedelta(minutes=30),
+            )
+            for name in ("first", "second")
+        ]
+        api = mock.MagicMock()
+        # The first pod's release blows up; the second must still be swept.
+        api.patch_namespaced_pod.side_effect = [_api_exception(500), None]
+
+        assert self._sweep(pods, api) == 1
+
+
+class TestTheLauncherProductionUses:
+    def test_the_pod_or_job_launcher_forwards_the_sweep(self) -> None:
+        # `_KubernetesPodOrJobLauncher` composes the pod launcher rather than
+        # inheriting from it, so without an explicit delegation the orchestrator
+        # would find no sweeper at all on the launcher production uses.
+        composite = mock.MagicMock(
+            spec=kubernetes_launchers._KubernetesPodOrJobLauncher
+        )
+        assert hasattr(composite, "release_abandoned_finalizer_holds")
+
+    def test_the_job_launcher_never_holds_its_pods(self) -> None:
+        # A Job outlives its pods, and a finalizer on Job-owned pods would wedge
+        # the Job controller's own cleanup.
+        assert not hasattr(
+            kubernetes_launchers._KubernetesJobLauncher,
+            "release_abandoned_finalizer_holds",
+        )
+
+
+class TestOrchestratorReleasesEveryTerminalPath:
+    def test_a_failing_release_never_changes_the_outcome(self) -> None:
+        launched = mock.MagicMock()
+        launched.release.side_effect = RuntimeError("kubernetes is having a day")
+        # The execution's result is already committed by the time we release.
+        orchestrator_sql._release_launched_container(launched)
+
+    def test_cancellation_releases_the_hold(self) -> None:
+        session_factory, launched = _create_launched_container_execution()
+        _mark_all_execution_nodes_terminated(session_factory)
+        orchestrator = _make_orchestrator(session_factory, launched)
+
+        orchestrator.internal_process_running_executions_queue(
+            session=session_factory()
+        )
+
+        # Cancellation deletes the pod and returns early: the execution is
+        # CANCELLED and will never be polled again, so if the hold is not
+        # released here the pod is stuck in `Terminating` for ever.
+        launched.terminate.assert_called_once()
+        launched.release.assert_called_once()
+        assert _container_execution_status(session_factory) == (
+            bts.ContainerExecutionStatus.CANCELLED
+        )
+
+    def test_a_still_running_execution_keeps_its_hold(self) -> None:
+        session_factory, launched = _create_launched_container_execution()
+        launched.status = launcher_interfaces.ContainerStatus.RUNNING
+        orchestrator = _make_orchestrator(session_factory, launched)
+
+        orchestrator.internal_process_running_executions_queue(
+            session=session_factory()
+        )
+
+        launched.release.assert_not_called()
+
+
+def _create_session_factory() -> Callable[[], orm.Session]:
+    db_engine = database_ops.create_db_engine_and_migrate_db(database_uri="sqlite://")
+    return lambda: orm.Session(bind=db_engine)
+
+
+def _make_launched_container_mock() -> mock.MagicMock:
+    return mock.MagicMock(
+        status=launcher_interfaces.ContainerStatus.PENDING,
+        to_dict=lambda: dict(_LAUNCHER_DATA),
+    )
+
+
+def _create_launched_container_execution() -> (
+    tuple[Callable[[], orm.Session], mock.MagicMock]
+):
+    """A pipeline run with one container task, launched and PENDING."""
+    pipeline_spec = structures.ComponentSpec(
+        implementation=structures.GraphImplementation(
+            graph=structures.GraphSpec(
+                tasks={
+                    "child": structures.TaskSpec(
+                        component_ref=structures.ComponentReference(
+                            spec=structures.ComponentSpec(
+                                implementation=structures.ContainerImplementation(
+                                    container=structures.ContainerSpec(image="python")
+                                )
+                            )
+                        )
+                    )
+                }
+            )
+        ),
+    )
+    root_task = structures.TaskSpec(
+        component_ref=structures.ComponentReference(spec=pipeline_spec)
+    )
+    session_factory = _create_session_factory()
+    api_server_sql.PipelineRunsApiService_Sql().create(
+        session=session_factory(),
+        root_task=root_task,
+        created_by="user1",
+    )
+    launched = _make_launched_container_mock()
+    launch_orchestrator = orchestrator_sql.OrchestratorService_Sql(
+        session_factory=session_factory,
+        launcher=mock.MagicMock(
+            launch_container_task=mock.MagicMock(return_value=launched),
+            release_abandoned_finalizer_holds=mock.MagicMock(return_value=0),
+        ),
+        storage_provider=mock.MagicMock(),
+        data_root_uri="file:///tmp/artifacts",
+        logs_root_uri="file:///tmp/logs",
+    )
+    session = session_factory()
+    for _ in range(20):
+        if not launch_orchestrator.internal_process_queued_executions_queue(
+            session=session
+        ):
+            break
+    return session_factory, launched
+
+
+def _make_orchestrator(
+    session_factory: Callable[[], orm.Session],
+    launched_container: mock.MagicMock,
+) -> orchestrator_sql.OrchestratorService_Sql:
+    launcher = mock.MagicMock(
+        deserialize_launched_container_from_dict=mock.MagicMock(
+            return_value=launched_container
+        ),
+        get_refreshed_launched_container_from_dict=mock.MagicMock(
+            return_value=launched_container
+        ),
+        release_abandoned_finalizer_holds=mock.MagicMock(return_value=0),
+    )
+    return orchestrator_sql.OrchestratorService_Sql(
+        session_factory=session_factory,
+        launcher=launcher,
+        storage_provider=mock.MagicMock(),
+        data_root_uri="file:///tmp/artifacts",
+        logs_root_uri="file:///tmp/logs",
+    )
+
+
+def _mark_all_execution_nodes_terminated(
+    session_factory: Callable[[], orm.Session],
+) -> None:
+    session = session_factory()
+    for execution_node in session.scalars(sql.select(bts.ExecutionNode)).all():
+        execution_node.extra_data = {"desired_state": "TERMINATED"}
+    session.commit()
+
+
+def _container_execution_status(
+    session_factory: Callable[[], orm.Session],
+) -> bts.ContainerExecutionStatus:
+    container_execution = session_factory().scalar(sql.select(bts.ContainerExecution))
+    assert container_execution is not None
+    return container_execution.status


### PR DESCRIPTION
The orchestrator can only learn how a task ended by reading the pod object:
`LaunchedKubernetesContainer.status` reads `pod.status.phase`, exit code and
timings come off the same object, and logs are fetched from the live pod at the
moment a terminal status is first seen. Nothing is streamed or persisted before
then. So if the pod is deleted between the container finishing and the next
poll, a task that succeeded is recorded as SYSTEM_ERROR, its downstream DAG is
skipped, and its logs are gone for good.

That window is not hypothetical and it is not ours to widen. On the cluster
these tasks run on, terminated pods are collected by a count-limited sweep in
pod-age order: the measured lag between a pod finishing and being deleted moved
between ~20 and ~200 minutes over a single day, and a pod older than the current
frontier is removed within seconds of terminating (one observed task ran for 634
minutes and its pod was gone in the same minute it succeeded). Node scale-down
takes the pods with it just as fast. The orchestrator re-polls a given pod once every `active_executions / ~2.2`
seconds. Its running-executions queue is a single round-robin over every
non-terminal execution ordered by `last_processed_at`: three polls per sweep,
a 1s sleep between sweeps, ~2.2 pod polls/sec in aggregate. Measured in
production at 147 active executions, the gap between two polls of the same pod
was 65s p50 and 60-76s across 453 samples. It scales linearly with fleet
concurrency, and active executions ranged 34 to 277 over the last week, so the
window is near two minutes at peak -- widest exactly when pod churn and node
scale-down are highest. The orchestrator loses both races, and the
garbage-collection threshold is a control-plane flag that a managed Kubernetes
offering does not expose.

Close the window from this side instead. When the hold is enabled, the pod
launcher stamps every pod it creates with a
`cloud-pipelines.net/status-observed` finalizer. A delete then only stamps
`deletionTimestamp`: the pod stays in `Terminating`, fully readable, until we
remove the finalizer. This does not retain pods for longer in the normal case;
it converts a race into a handshake, and the pod is released as soon as its
outcome has been recorded.

The hold is the easy half. The release is the half that has to be exhaustive,
because a pod that is held and never released sits in `Terminating` for ever,
consuming etcd space and namespace pod quota and eating the cluster's pod-GC
budget. Every path that terminalizes an execution now releases:

- a terminal status observed by the poll loop, after status, exit code, logs
and output artifacts are all committed;
- cancellation, which deletes the pod, marks the execution CANCELLED and
returns early, so nothing would ever poll it again -- this is the most common
Tangle-initiated deletion, and without an explicit release here every
cancellation would wedge a pod;
- the SYSTEM_ERROR handler in the running-executions queue, which terminalizes
an execution the poll loop could not process.

And a backstop for everything else (the orchestrator restarting mid-flight, an
execution row that no longer exists, a pod whose node was deleted so it never
reaches a terminal phase): `release_abandoned_finalizer_holds` force-releases
any held pod whose deletion has been pending longer than
`finalizer_hold_max_duration` (default 10 minutes), swept at most once per
`finalizer_sweep_interval` (default 60s) from the running-executions queue. The
worst case is therefore bounded by configuration rather than by correctness of
the release paths.

Deliberate choices worth knowing about:

- Off by default. A hold that is never released is worse than a pod collected
too early. Enable per launcher with `hold_pods_until_status_observed=True`, or
with `CLOUD_PIPELINES_HOLD_PODS_UNTIL_STATUS_OBSERVED=true` for deployments
that build the launcher without threading the argument through.
- Pods only, never Jobs. A Job outlives its pods, so the Job launcher does not
need this, and a finalizer on Job-owned pods would wedge the Job controller's
own cleanup. `_KubernetesPodOrJobLauncher` composes rather than inherits, so
it forwards the sweep explicitly and passes the hold to the pod launcher only.
- The finalizer is added after the pod post-processor runs and before the pod is
created, so a post-processor cannot drop it and the pod is never unprotected.
- Removal uses a JSON Patch with a `test` op. `metadata.finalizers` has merge
semantics, so a strategic merge patch can add a finalizer but never remove
one; the `test` op makes removal atomic against a concurrent writer, and a
conflict is retried.
- The sweep lists pods cluster-wide, because a pod post-processor may place pods
in a namespace other than the launcher's own. That needs `list pods` at
cluster scope; without it the sweep logs and returns, and the per-execution
releases still work.
- Releasing is always best-effort at the call sites: the execution's outcome is
already committed, so a failure to release must never change it.

This protects status and exit code. Logs survive only as long as the node does:
if the node is gone, `read_namespaced_pod_log` fails whether or not the pod
object is held, which is why log upload stays best-effort.

Co-authored-by: Morgan Wowk [morgan.wowk@shopify.com](mailto:morgan.wowk@shopify.com)