### PR TITLE
feat: Orchestrator - Support container cleanup after the execution has ended

### DIFF
--- a/cloud_pipelines_backend/launchers/huggingface_launchers.py
+++ b/cloud_pipelines_backend/launchers/huggingface_launchers.py
@@ -445,6 +445,9 @@ class LaunchedHuggingFaceJobContainer(interfaces.LaunchedContainer):
     def terminate(self):
         self._get_api_client().cancel_job(job_id=self._id, namespace=self._namespace)
 
+    def cleanup(self):
+        pass
+
     def to_dict(self) -> dict[str, Any]:
         debug_job_info = dataclasses.asdict(self._job)
         # Fix JSON serialization of datetime

--- a/cloud_pipelines_backend/launchers/interfaces.py
+++ b/cloud_pipelines_backend/launchers/interfaces.py
@@ -137,6 +137,9 @@ class LaunchedContainer(abc.ABC):
     def terminate(self) -> None:
         raise NotImplementedError()
 
+    def cleanup(self) -> None:
+        pass
+
 
 # @dataclasses.dataclass
 # class ContainerExecutionResult:

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -972,7 +972,7 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
 
         return pprint.pformat(self.to_dict())
 
-    def terminate(self):
+    def _delete_pod(self):
         launcher = self._get_launcher()
         core_api_client = k8s_client_lib.CoreV1Api(api_client=launcher._api_client)
         core_api_client.delete_namespaced_pod(
@@ -980,7 +980,13 @@ class LaunchedKubernetesContainer(interfaces.LaunchedContainer):
             namespace=self._namespace,
             grace_period_seconds=10,
         )
+
+    def terminate(self):
+        self._delete_pod()
         _logger.info(f"Terminated pod {self._pod_name} in namespace {self._namespace}")
+
+    def cleanup(self):
+        self._delete_pod()
 
 
 class _KubernetesJobLauncher(
@@ -1607,7 +1613,7 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
 
         return pprint.pformat(self.to_dict())
 
-    def terminate(self):
+    def _delete_job(self):
         launcher = self._get_launcher()
         batch_api_client = k8s_client_lib.BatchV1Api(api_client=launcher._api_client)
         batch_api_client.delete_namespaced_job(
@@ -1616,7 +1622,13 @@ class LaunchedKubernetesJob(interfaces.LaunchedContainer):
             grace_period_seconds=10,
             propagation_policy="Foreground",
         )
+
+    def terminate(self):
+        self._delete_job()
         _logger.info(f"Terminated job {self._job_name} in namespace {self._namespace}")
+
+    def cleanup(self) -> None:
+        self._delete_job()
 
 
 class _KubernetesPodOrJobLauncher(

--- a/cloud_pipelines_backend/launchers/local_docker_launchers.py
+++ b/cloud_pipelines_backend/launchers/local_docker_launchers.py
@@ -335,6 +335,9 @@ class LaunchedDockerContainer(interfaces.LaunchedContainer):
     def terminate(self):
         self._container.stop(timeout=10)
 
+    def cleanup(self) -> None:
+        self._container.remove()
+
     def to_dict(self) -> dict[str, Any]:
         return dict(
             docker=dict(

--- a/cloud_pipelines_backend/launchers/skypilot_launchers.py
+++ b/cloud_pipelines_backend/launchers/skypilot_launchers.py
@@ -744,6 +744,9 @@ class SkyPilotLaunchedJob(interfaces.LaunchedContainer):
         request_id = sky_jobs.cancel(job_ids=[self._handle.job_id])
         sky.get(request_id)
 
+    def cleanup(self) -> None:
+        pass
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "skypilot": {

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -1028,6 +1028,18 @@ class OrchestratorService_Sql:
             )
         session.commit()
 
+        # Cleaning up after the jobs. But only when container succeeds/fails, not gets SYSTEM_ERROR.
+        if new_status in (
+            launcher_interfaces.ContainerStatus.SUCCEEDED,
+            launcher_interfaces.ContainerStatus.FAILED,
+        ):
+            try:
+                launched_container.cleanup()
+            except Exception:
+                _logger.exception(
+                    f"Processing running container execution {container_execution.id}: Error doing launched container cleanup."
+                )
+
 
 def _get_direct_downstream_executions(
     session: orm.Session, execution: bts.ExecutionNode


### PR DESCRIPTION
This fixes the accumulation of stale containers in execution systems like Kubernetes and Docker. If the execution gets into SYSTEM_ERROR state, we do not do cleanup to preserve the data for debugging.