### PR TITLE
Trace GCS upload/download duration and bytes

### DIFF
--- a/cloud_pipelines_backend/instrumentation/gcs_tracing.py
+++ b/cloud_pipelines_backend/instrumentation/gcs_tracing.py
@@ -1,0 +1,64 @@
+"""GCS storage provider that emits one OTel span per upload/download so transfer duration is measurable."""
+
+from __future__ import annotations
+
+import collections.abc
+import contextlib
+
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
+from cloud_pipelines.orchestration.storage_providers import google_cloud_storage
+
+_tracer = trace.get_tracer("tangle.storage")
+
+
+@contextlib.contextmanager
+def _gcs_operation_span(
+    operation: str, uri: str
+) -> collections.abc.Iterator[trace.Span]:
+    with _tracer.start_as_current_span(
+        f"gcs.{operation}",
+        attributes={"gcs.operation": operation, "gcs.uri": uri},
+    ) as span:
+        try:
+            yield span
+        except Exception as exception:
+            span.set_status(StatusCode.ERROR)
+            span.record_exception(exception)
+            raise
+
+
+class TracingGoogleCloudStorageProvider(
+    google_cloud_storage.GoogleCloudStorageProvider
+):
+    def upload(
+        self,
+        source_path: str,
+        destination_uri: google_cloud_storage.GoogleCloudStorageUri,
+    ) -> None:
+        with _gcs_operation_span("upload", destination_uri.uri):
+            super().upload(source_path, destination_uri)
+
+    def upload_bytes(
+        self, data: bytes, destination_uri: google_cloud_storage.GoogleCloudStorageUri
+    ) -> None:
+        with _gcs_operation_span("upload_bytes", destination_uri.uri) as span:
+            span.set_attribute("gcs.bytes", len(data))
+            super().upload_bytes(data, destination_uri)
+
+    def download(
+        self,
+        source_uri: google_cloud_storage.GoogleCloudStorageUri,
+        destination_path: str,
+    ) -> None:
+        with _gcs_operation_span("download", source_uri.uri):
+            super().download(source_uri, destination_path)
+
+    def download_bytes(
+        self, source_uri: google_cloud_storage.GoogleCloudStorageUri
+    ) -> bytes:
+        with _gcs_operation_span("download_bytes", source_uri.uri) as span:
+            data = super().download_bytes(source_uri)
+            span.set_attribute("gcs.bytes", len(data))
+            return data

--- a/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/google_kubernetes_launchers.py
@@ -2,9 +2,8 @@ import typing
 
 from kubernetes import client as k8s_client_lib
 
-from cloud_pipelines.orchestration.storage_providers import google_cloud_storage
-
 from . import kubernetes_launchers
+from ..instrumentation import gcs_tracing
 
 if typing.TYPE_CHECKING:
     from google.cloud import storage
@@ -44,9 +43,7 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesJobLauncher(
             pod_labels=pod_labels,
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,
-            _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
-                gcs_client
-            ),
+            _storage_provider=gcs_tracing.TracingGoogleCloudStorageProvider(gcs_client),
             _create_volume_and_volume_mount=kubernetes_launchers._create_volume_and_volume_mount_google_cloud_storage,
         )
 
@@ -87,8 +84,6 @@ class GoogleKubernetesEngine_UsingGoogleCloudStorage_KubernetesPodOrJobLauncher(
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,
             always_launch_jobs=always_launch_jobs,
-            _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
-                gcs_client
-            ),
+            _storage_provider=gcs_tracing.TracingGoogleCloudStorageProvider(gcs_client),
             _create_volume_and_volume_mount=kubernetes_launchers._create_volume_and_volume_mount_google_cloud_storage,
         )

--- a/cloud_pipelines_backend/launchers/kubernetes_launchers.py
+++ b/cloud_pipelines_backend/launchers/kubernetes_launchers.py
@@ -724,7 +724,7 @@ class GoogleKubernetesEngineLauncher(_KubernetesPodLauncher):
             pod_postprocessors.append(pod_postprocessor)
         final_pod_postporocessor = _create_pod_postprocessor_stack(pod_postprocessors)
 
-        from cloud_pipelines.orchestration.storage_providers import google_cloud_storage
+        from ..instrumentation import gcs_tracing
 
         super().__init__(
             namespace=namespace,
@@ -732,9 +732,7 @@ class GoogleKubernetesEngineLauncher(_KubernetesPodLauncher):
             api_client=api_client,
             request_timeout=request_timeout,
             pod_name_prefix=pod_name_prefix,
-            _storage_provider=google_cloud_storage.GoogleCloudStorageProvider(
-                gcs_client
-            ),
+            _storage_provider=gcs_tracing.TracingGoogleCloudStorageProvider(gcs_client),
             pod_labels=pod_labels,
             pod_annotations={"gke-gcsfuse/volumes": "true"} | (pod_annotations or {}),
             pod_postprocessor=final_pod_postporocessor,


### PR DESCRIPTION
## Why

A recent incident had Tangle pipelines stalling on GCS transfers. The first fix attempt was per-request timeouts ([#330](https://github.com/TangleML/tangle/pull/330), now closed), but the stock `google-cloud-storage` client already enforces a 60s per-request timeout plus a ~120s retry deadline, so a same-default override added little. Before choosing any timeout policy we need to know **how long real uploads/downloads take on prod** — so we can find concretely where the time goes and which operation to focus on.

## Out of scope

GCS Fuse operations, which is the more impactful area to measure, is not covered by this change.

## Changes

- New `cloud_pipelines_backend/instrumentation/gcs_tracing.py`: `TracingGoogleCloudStorageProvider`, a subclass of the upstream `GoogleCloudStorageProvider` that overrides only the four public transfer methods (`upload`, `upload_bytes`, `download`, `download_bytes`). Each wraps `super()` in an OpenTelemetry span.
- The GKE launchers now construct the tracing provider instead of the plain one (one-line swap at each site; the positional `gcs_client` argument is unchanged).

Each span uses the `tangle.storage` tracer, is named `gcs.<operation>`, and carries:
- `gcs.operation` — `upload` / `upload_bytes` / `download` / `download_bytes`
- `gcs.uri` — the object/prefix being transferred
- `gcs.bytes` — payload size, recorded **only** for the in-memory transfers (`upload_bytes` / `download_bytes`, where it is a free `len(data)`)

On failure the span is marked `ERROR` and the exception is recorded, then re-raised unchanged.

**Duration is the primary signal** and is intrinsic to every span. We deliberately do **not** walk the local filesystem to size file/dir transfers: that scan is strictly dominated by the transfer it would measure (the base provider already does one GCS round-trip per file), it added a robustness hole (a `stat` race could fail an otherwise-successful transfer), and authoritative sizes for those artifacts already live in `artifact_data.total_size` and can be joined offline.

## System / UX impact

- **Measurement only** — no transfer behavior changes; `__init__` is not overridden and no timeouts are introduced.
- Adds one span per GCS transfer (exported via the already-configured OTLP `BatchSpanProcessor`). No extra filesystem access.

## Before / after

- **Before:** GCS transfer latency was invisible; we could only guess where time went.
- **After:** every launcher-side upload/download emits a span with its duration, queryable in Observe by operation and URI.

## Follow-up

Companion oasis-backend PR bumps the submodule and swaps the orchestrator-side provider so orchestrator-initiated GCS ops (`exists`, `get_info`, small `download_bytes`, output preservation) are covered too.