### PR TITLE
feat(orchestrator): Telemetry - Trace running execution processing time

### DIFF
--- a/cloud_pipelines_backend/instrumentation/orchestrator_tracing.py
+++ b/cloud_pipelines_backend/instrumentation/orchestrator_tracing.py
@@ -1,0 +1,24 @@
+"""OTel spans for the orchestrator processing loop so per-execution processing time is measurable."""
+
+from __future__ import annotations
+
+import collections.abc
+import contextlib
+
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
+_tracer = trace.get_tracer("tangle.orchestrator")
+
+
+@contextlib.contextmanager
+def operation_span(
+    name: str, *, attributes: dict[str, object] | None = None
+) -> collections.abc.Iterator[trace.Span]:
+    with _tracer.start_as_current_span(name, attributes=attributes) as span:
+        try:
+            yield span
+        except Exception as exception:
+            span.set_status(StatusCode.ERROR)
+            span.record_exception(exception)
+            raise

--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -25,6 +25,7 @@ from .launchers import interfaces as launcher_interfaces
 from .instrumentation import bugsnag_instrumentation
 from .instrumentation import contextual_logging
 from .instrumentation import metrics as app_metrics
+from .instrumentation import orchestrator_tracing
 
 _logger = logging.getLogger(__name__)
 
@@ -229,10 +230,16 @@ class OrchestratorService_Sql:
                     f"Before processing running container execution. Queries duration {queries_duration_ms}ms."
                 )
                 try:
-                    self.internal_process_one_running_execution(
-                        session=session,
-                        container_execution=running_container_execution,
-                    )
+                    with orchestrator_tracing.operation_span(
+                        "orchestrator.process_running_execution",
+                        attributes={
+                            "container_execution.id": running_container_execution.id
+                        },
+                    ):
+                        self.internal_process_one_running_execution(
+                            session=session,
+                            container_execution=running_container_execution,
+                        )
                 except Exception as ex:
                     _logger.exception("Error processing running container execution")
                     session.rollback()


### PR DESCRIPTION
Wraps the per-running-execution processing call in `internal_process_running_executions_queue` in a `tangle.orchestrator` span (`orchestrator.process_running_execution`), attributed by `container_execution.id`.

## Why
Investigation of inv-26772 (orchestrator intermittently stalling) showed that attributing a freeze to the execution that caused it currently requires hand-correlating the `After processing running container execution (duration: …ms)` log with the launcher logs to recover the namespace. This span makes that per-execution processing duration a first-class, queryable signal keyed by the execution id, so "which execution blocked the loop, and for how long" is a single query instead of manual log archaeology.

Complements the query-timing logs added in [#331](https://github.com/TangleML/tangle/pull/331) by turning the per-execution processing duration into an attributed span.

## Naming
Uses `container_execution.id` (not `execution.id`): the processing loop operates on a `ContainerExecution`, matching the `contextual_logging` key and the `cloud-pipelines.net/orchestration/container_execution.id` annotation. `execution_tracing.py` already uses `execution.id` for an `ExecutionNode` (a different entity), so this avoids overloading one key for two entities.

## Impact
One span per running-execution processing pass; it becomes the parent for any child spans emitted during processing. No behavior change.