### PR TITLE
feat(orchestrator): Telemetry - Trace the execution output artifacts info retrieval time

### DIFF
--- a/cloud_pipelines_backend/orchestrator_sql.py
+++ b/cloud_pipelines_backend/orchestrator_sql.py
@@ -1017,14 +1017,17 @@ class OrchestratorService_Sql:
                         session=session, execution=execution_node
                     )
             else:
-                output_artifact_data_info_map = {
-                    output_name: _retry(
-                        lambda: self._storage_provider.make_uri(uri)
-                        .get_reader()
-                        .get_info()
-                    )
-                    for output_name, uri in output_artifact_uris.items()
-                }
+                with orchestrator_tracing.operation_span(
+                    "orchestrator.get_output_artifact_info"
+                ):
+                    output_artifact_data_info_map = {
+                        output_name: _retry(
+                            lambda: self._storage_provider.make_uri(uri)
+                            .get_reader()
+                            .get_info()
+                        )
+                        for output_name, uri in output_artifact_uris.items()
+                    }
                 new_output_artifact_data_map = {
                     output_name: bts.ArtifactData(
                         total_size=data_info.total_size,


### PR DESCRIPTION
Wraps the output-artifact `get_info()` resolution in the `SUCCEEDED` branch of `internal_process_one_running_execution` in a child span (`orchestrator.get_output_artifact_info`).

## Why
This `get_reader().get_info()` call walks and stats **every file** of each output artifact on the single orchestrator thread. For a large Directory artifact (the inv-26772 trigger: ~88k per-merchant files) this is the confirmed freeze hot path — it runs for 40+ minutes and blocks all other executions. The span isolates that hot path within the parent processing span so its duration is directly measurable.

Timing-only, by design: per review, artifact **byte size** does not predict the stall (multi-gig artifacts resolve fast); **file count** is the meaningful dimension but is not available cheaply at this point, so no attribute is attached rather than a misleading one.

## Impact
One child span per succeeded execution's output resolution, nested under `orchestrator.process_running_execution` from [#334](https://github.com/TangleML/tangle/pull/334). No behavior change.