### PR TITLE
fix(tests): reset OTel tracer provider to None to stop cross-test recursion

### DIFF
--- a/tests/instrumentation/opentelemetry/conftest.py
+++ b/tests/instrumentation/opentelemetry/conftest.py
@@ -13,6 +13,6 @@ def reset_otel_providers():
     """
     yield
     trace._TRACER_PROVIDER_SET_ONCE._done = False
-    trace._TRACER_PROVIDER = trace.ProxyTracerProvider()
+    trace._TRACER_PROVIDER = None
     otel_metrics._internal._METER_PROVIDER_SET_ONCE._done = False
     otel_metrics._internal._METER_PROVIDER = None


### PR DESCRIPTION
## Problem

Running the full `tests/` suite produced 6 failures that were **not reproducible when the affected files were run in isolation**:

```
FAILED tests/test_container_execution_refresh_retries.py::...::test_missing_workload_is_counted_and_terminalizes
FAILED tests/test_container_execution_refresh_retries.py::...::test_retriable_errors_below_budget_leave_execution_running
FAILED tests/test_container_execution_refresh_retries.py::...::test_successful_refresh_resets_the_budget
FAILED tests/test_container_execution_refresh_retries.py::...::test_retry_moves_execution_to_the_back_of_the_queue
FAILED tests/test_container_execution_refresh_retries.py::...::test_failing_execution_does_not_hold_up_the_queue
FAILED tests/test_orchestrator_failed_log_upload.py::test_failed_execution_survives_log_upload_failure
```

The failures were a symptom (`SYSTEM_ERROR` instead of `PENDING`, mocks never called, timestamps not advancing), with a `RecursionError: maximum recursion depth exceeded` buried in the output.

## Root cause

The `reset_otel_providers` autouse fixture in [tests/instrumentation/opentelemetry/conftest.py](tests/instrumentation/opentelemetry/conftest.py) reset the global tracer provider to a fresh `ProxyTracerProvider()`:

```python
trace._TRACER_PROVIDER = trace.ProxyTracerProvider()   # ← self-referential
```

OpenTelemetry's `ProxyTracerProvider.get_tracer()` delegates to the module-global `trace._TRACER_PROVIDER`. Once that global **is** a `ProxyTracerProvider`, the delegation points back at itself, so `start_as_current_span` recurses until `RecursionError`.

Because the fixture mutates OTel's **process-global** state, the broken provider leaked out of the `opentelemetry/` test package into the rest of the suite (default collection order runs it before `test_container_execution_refresh_retries`). Later tests that emit spans via `orchestrator_tracing.operation_span` / `execution_tracing.emit_execution_trace` hit the `RecursionError`; the orchestrator caught it as a generic processing error and drove container executions to `SYSTEM_ERROR`, which is what the assertions actually tripped on.

## Fix

Reset to `None`, matching the meter-provider reset on the very next line:

```python
trace._TRACER_PROVIDER = None
```

With `None`, `get_tracer_provider()` falls back to OTel's internal `_PROXY_TRACER_PROVIDER` and `ProxyTracer` resolves to the no-op tracer — no self-delegation, no recursion.

## Verification

- Before: `6 failed, 462 passed` (full suite)
- After: `468 passed` (full suite, `pytest tests/`)
- The previously-failing files still pass in isolation, and the `opentelemetry/` suite that owns the fixture continues to pass.

## Downstream

This is beneficial to downstream applications with their own suite of tests against OTEL. 